### PR TITLE
Add envsubst tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/VividCortex/ewma v1.1.1 // indirect
+	github.com/a8m/envsubst v1.4.2 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/apache/openwhisk-wskdeploy v0.0.0-20221221215944-0e9b45ff5ff3 // indirect
@@ -59,6 +60,7 @@ require (
 	github.com/mattn/go-zglob v0.0.4 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/mtibben/androiddnsfix v0.0.0-20200907095054-ff0280446354 // indirect
+	github.com/nuvolaris/envsubst/cmd/envsubstmain v0.0.0-20230316170831-d78a244e9675 // indirect
 	github.com/nuvolaris/goja/gojamain v0.0.0-20230315181922-61fd5fa112c9 // indirect
 	github.com/nuvolaris/sh/v3 v3.0.0-20230312215406-ee139db1ecdb // indirect
 	github.com/nuvolaris/task/v3 v3.9.3-0.20230216111806-00c2fce2c9af // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 h1:ra2OtmuW0A
 github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4/go.mod h1:UBYPn8k0D56RtnR8RFQMjmh4KrZzWJ5o7Z9SYjossQ8=
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
+github.com/a8m/envsubst v1.4.2 h1:4yWIHXOLEJHQEFd4UjrWDrYeYlV7ncFWJOCBRLOZHQg=
+github.com/a8m/envsubst v1.4.2/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
@@ -267,6 +269,16 @@ github.com/nicksnyder/go-i18n v1.10.1/go.mod h1:e4Di5xjP9oTVrC6y3C7C0HoSYXjSbhh/
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nojima/httpie-go v0.7.0 h1:lmDVJ1i9/Qk3YbJuABjH5lk8oqk3BtpJv32fQ0mo6/g=
 github.com/nojima/httpie-go v0.7.0/go.mod h1:47dAVOiAcG0ZETwg+P42Kj+3JrSEC9kWm8f+hirX2Mw=
+github.com/nuvolaris/envsubst/cmd/envsubstmain v0.0.0-20230316165535-f484616940d4 h1:BCm4evt+AIfd/axrCvyoTYDOeYxzQh96KZ6ZXwM6YB0=
+github.com/nuvolaris/envsubst/cmd/envsubstmain v0.0.0-20230316165535-f484616940d4/go.mod h1:scN6eGT0YjABIs2bLh+CfWdOFZgmkefhv0pA9RBCEaM=
+github.com/nuvolaris/envsubst/cmd/envsubstmain v0.0.0-20230316165948-b335c80c6859 h1:yq0mWkfzNxQlj6A3/WT+6+ARWrwAnYN+bWj41VnUZxM=
+github.com/nuvolaris/envsubst/cmd/envsubstmain v0.0.0-20230316165948-b335c80c6859/go.mod h1:scN6eGT0YjABIs2bLh+CfWdOFZgmkefhv0pA9RBCEaM=
+github.com/nuvolaris/envsubst/cmd/envsubstmain v0.0.0-20230316170416-8fe0e273c58e h1:AEd7GQHL98WGGVYXHy6w8kjTATYzieSLmS0mUKjKfkU=
+github.com/nuvolaris/envsubst/cmd/envsubstmain v0.0.0-20230316170416-8fe0e273c58e/go.mod h1:scN6eGT0YjABIs2bLh+CfWdOFZgmkefhv0pA9RBCEaM=
+github.com/nuvolaris/envsubst/cmd/envsubstmain v0.0.0-20230316170725-f7eea695b6a2 h1:oEByFs+HytUCX3k2NJlqZPT8j8nhW52m6VqhUAweF0Y=
+github.com/nuvolaris/envsubst/cmd/envsubstmain v0.0.0-20230316170725-f7eea695b6a2/go.mod h1:scN6eGT0YjABIs2bLh+CfWdOFZgmkefhv0pA9RBCEaM=
+github.com/nuvolaris/envsubst/cmd/envsubstmain v0.0.0-20230316170831-d78a244e9675 h1:C4LgC+o+zpRlpblKvhHA/O7p8ej8SriAC2AkgYjfxBo=
+github.com/nuvolaris/envsubst/cmd/envsubstmain v0.0.0-20230316170831-d78a244e9675/go.mod h1:scN6eGT0YjABIs2bLh+CfWdOFZgmkefhv0pA9RBCEaM=
 github.com/nuvolaris/goawk v1.21.1-0.20230314201833-d0931fd55c2c h1:L9HLHEk9rLllwSYyzg8fu7ScPfCX773sWu55TzavywQ=
 github.com/nuvolaris/goawk v1.21.1-0.20230314201833-d0931fd55c2c/go.mod h1:/9Rq7gSfPOW2G7aq2Rii4kbNl9o3GJSGvBjikGMs74I=
 github.com/nuvolaris/goja/gojamain v0.0.0-20230315180139-1dbc02c446d4 h1:tSfJFQTVz8/ZCKPJfBS+UqO35gsrWURjUey2587ZwXg=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -22,12 +22,13 @@ import (
 
 	gojq "github.com/itchyny/gojq/cli"
 	"github.com/nojima/httpie-go"
+	envsubst "github.com/nuvolaris/envsubst/cmd/envsubstmain"
 	"github.com/nuvolaris/goawk"
 	goja "github.com/nuvolaris/goja/gojamain"
 )
 
 var tools = []string{
-	"awk", "jq", "js", "wsk", "ht",
+	"awk", "jq", "js", "envsubst", "wsk", "ht",
 }
 
 func IsTool(name string) bool {
@@ -85,6 +86,11 @@ func RunTool(name string, args []string) (int, error) {
 	case "js":
 		os.Args = append([]string{"goja"}, args...)
 		if err := goja.GojaMain(); err != nil {
+			return 1, err
+		}
+	case "envsubst":
+		os.Args = append([]string{"envsubst"}, args...)
+		if err := envsubst.EnvsubstMain(); err != nil {
 			return 1, err
 		}
 	}


### PR DESCRIPTION
This PR closes #5 

It adds the envsubst tool from the github.com/nuvolaris/envsubst/cmd/envsubstmain repo, and it can be used as `nuv -envsubst`