### PR TITLE
Add prefix usage to run tasks

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,6 +102,10 @@ func main() {
 	if len(args) > 1 && len(args[1]) > 0 && args[1][0] == '-' {
 		cmd := args[1][1:]
 		if cmd == "" || cmd == "-" || cmd == "task" {
+			if len(args) < 3 {
+				taskmain.Task(args[1:])
+				os.Exit(0)
+			}
 			taskmain.Task(args[2:])
 			os.Exit(0)
 		}
@@ -146,5 +150,9 @@ func main() {
 	// check if olaris was recently updated
 	// we pass parent(dir) because we use the olaris parent folder
 	checkUpdated(parent(dir), 24*time.Hour)
-	Nuv(dir, args[1:])
+
+	if err := Nuv(dir, args[1:]); err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
 }

--- a/nuv.go
+++ b/nuv.go
@@ -189,7 +189,7 @@ func validateTaskName(name string) (string, error) {
 		return candidates[0], nil
 	}
 
-	return "", fmt.Errorf("ambiguous task: %s. possible tasks: %v", name, candidates)
+	return "", fmt.Errorf("ambiguous task: %s. Possible tasks: %v", name, candidates)
 }
 
 // obtains the task names from the nuvfile.yaml inside the given directory
@@ -203,7 +203,7 @@ func getTaskNamesList(dir string) []string {
 
 		err = yaml.Unmarshal(dat, &m)
 		if err != nil {
-			warn("error checking task list")
+			warn("error reading nuvfile.yml")
 			return make([]string, 0)
 		}
 		tasksMap, ok := m["tasks"].(map[string]interface{})

--- a/nuv.go
+++ b/nuv.go
@@ -94,13 +94,18 @@ func Nuv(base string, args []string) error {
 	rest := args
 
 	for _, task := range args {
-		trace("task", task)
-		// try to correct name if it's a prefix
+		trace("task name", task)
+
+		// skip flags
+		if strings.HasPrefix(task, "-") {
+			continue
+		}
+
+		// try to correct name if it's not a flag
 		taskName, err := validateTaskName(task)
 		if err != nil {
 			return err
 		}
-
 		// if valid, check if it's a folder and move to it
 		if isDir(taskName) && exists(taskName, NUVFILE) {
 			os.Chdir(taskName)
@@ -108,6 +113,10 @@ func Nuv(base string, args []string) error {
 			rest = rest[1:]
 		} else {
 			// stop when non folder reached
+			//substitute it with the validated task name
+			if len(rest) == 1 {
+				rest[0] = taskName
+			}
 			break
 		}
 	}
@@ -155,6 +164,9 @@ func Nuv(base string, args []string) error {
 // 3. If the prefix is valid for more than one task, return an error
 // 4. If the prefix is not valid for any task, return an error
 func validateTaskName(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("task name is empty")
+	}
 	pwd, _ := os.Getwd()
 
 	candidates := []string{}

--- a/nuv.go
+++ b/nuv.go
@@ -105,7 +105,6 @@ func Nuv(base string, args []string) error {
 		if isDir(taskName) && exists(taskName, NUVFILE) {
 			os.Chdir(taskName)
 			//remove it from the args
-			// rest = append(rest[:i], rest[i+1:]...)
 			rest = rest[1:]
 		} else {
 			// stop when non folder reached
@@ -132,16 +131,7 @@ func Nuv(base string, args []string) error {
 		return nil
 	}
 
-	// get first string without '=' from rest, it's the task name
-	idx := 0
-	for i, s := range rest {
-		if !strings.Contains(s, "=") {
-			idx = i
-			break
-		}
-	}
-
-	mainTask := rest[idx]
+	mainTask := rest[0]
 
 	// unparsed args - separate variable assignments from extra args
 	pre := []string{"-t", NUVFILE, mainTask}
@@ -208,7 +198,7 @@ func getTaskNamesList(dir string) []string {
 		}
 		tasksMap, ok := m["tasks"].(map[string]interface{})
 		if !ok {
-			warn("error checking task list, perhaps no tasks defined?")
+			// warn("error checking task list, perhaps no tasks defined?")
 			return make([]string, 0)
 		}
 

--- a/nuv.go
+++ b/nuv.go
@@ -18,12 +18,12 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"sort"
 	"strings"
 
 	docopt "github.com/docopt/docopt-go"
+	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 
@@ -104,6 +104,8 @@ func Nuv(base string, args []string) error {
 		// if valid, check if it's a folder and move to it
 		if isDir(taskName) && exists(taskName, NUVFILE) {
 			os.Chdir(taskName)
+			//remove it from the args
+			// rest = append(rest[:i], rest[i+1:]...)
 			rest = rest[1:]
 		} else {
 			// stop when non folder reached
@@ -130,13 +132,16 @@ func Nuv(base string, args []string) error {
 		return nil
 	}
 
-	// rest[0] is the main task name <-- perform validating logic here
-	mainTask, err := validateTaskName(rest[0])
-	if err != nil {
-		return err
+	// get first string without '=' from rest, it's the task name
+	idx := 0
+	for i, s := range rest {
+		if !strings.Contains(s, "=") {
+			idx = i
+			break
+		}
 	}
-	log.Println("main task", mainTask)
-	// rest[1:] not containing '=' are sub tasks <-- if success, perform validating logic here
+
+	mainTask := rest[idx]
 
 	// unparsed args - separate variable assignments from extra args
 	pre := []string{"-t", NUVFILE, mainTask}
@@ -164,6 +169,9 @@ func validateTaskName(name string) (string, error) {
 
 	candidates := []string{}
 	tasks := getTaskNamesList(pwd)
+	if !slices.Contains(tasks, "help") {
+		tasks = append(tasks, "help")
+	}
 	for _, t := range tasks {
 		if t == name {
 			return name, nil

--- a/nuv_test.go
+++ b/nuv_test.go
@@ -95,6 +95,37 @@ func ExampleParseArgs() {
 	// 4 [__fa=false __fb=true __fl= __help=false __version=false _c=false _h=false _name_=() _x_=4 _y_=5 arg1=false arg2=false arg3=true args=false hello=false opt1=false opt2=true]
 }
 
+func Test_validateTaskName(t *testing.T) {
+	testNuvfile := "tasks:\n  task1: a\n  task2: b\n  test: c\n"
+
+	type validateTaskTest struct {
+		argTask  string
+		expected string
+	}
+
+	var validateTaskTests = []validateTaskTest{
+		{"help", "help"},
+		{"task1", "task1"},
+		{"te", "test"},
+		{"t", "ambiguous task: t. Possible tasks: [task1 task2 test]"},
+		{"no-task", "no task named no-task found"},
+	}
+
+	tmpDir := createTmpNuvfile(t, testNuvfile)
+	defer os.RemoveAll(tmpDir)
+	os.Chdir(tmpDir)
+	for _, tt := range validateTaskTests {
+		task, err := validateTaskName(tt.argTask)
+		if err != nil && err.Error() != tt.expected {
+			t.Fatalf("want error: %s, got: %v", tt.expected, err)
+		}
+		if err == nil && task != tt.expected {
+			t.Fatalf("want task: %s, got: %s", tt.argTask, task)
+		}
+
+	}
+}
+
 func Test_getTaskNamesList(t *testing.T) {
 	t.Run("empty nuvfile should return empty array", func(t *testing.T) {
 		tmpDir := createTmpNuvfile(t, "")

--- a/nuv_test.go
+++ b/nuv_test.go
@@ -27,7 +27,7 @@ import (
 func ExampleNuvArg() {
 	// test
 	os.Chdir(workDir)
-	olaris, _ := filepath.Abs("olaris")
+	olaris, _ := filepath.Abs(joinpath("tests", "olaris"))
 	err := Nuv(olaris, split("testcmd"))
 	pr(2, err)
 	err = Nuv(olaris, split("testcmd arg"))
@@ -109,6 +109,7 @@ func Test_validateTaskName(t *testing.T) {
 		{"te", "test"},
 		{"t", "ambiguous task: t. Possible tasks: [task1 task2 test]"},
 		{"no-task", "no task named no-task found"},
+		{"", "task name is empty"},
 	}
 
 	tmpDir := createTmpNuvfile(t, testNuvfile)

--- a/nuv_test.go
+++ b/nuv_test.go
@@ -20,28 +20,30 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"golang.org/x/exp/slices"
 )
 
 func ExampleNuvArg() {
 	// test
 	os.Chdir(workDir)
-	olaris, _ := filepath.Abs(joinpath("tests", "olaris"))
-	err := Nuv(olaris, split("top"))
+	olaris, _ := filepath.Abs("olaris")
+	err := Nuv(olaris, split("testcmd"))
 	pr(2, err)
-	err = Nuv(olaris, split("top arg"))
+	err = Nuv(olaris, split("testcmd arg"))
 	pr(3, err)
-	err = Nuv(olaris, split("top arg VAR=1"))
+	err = Nuv(olaris, split("testcmd arg VAR=1"))
 	pr(4, err)
-	err = Nuv(olaris, split("top VAR=1 arg"))
+	err = Nuv(olaris, split("testcmd VAR=1 arg"))
 	pr(5, err)
 	// Output:
-	// (olaris) task [-t nuvfile.yml top --]
+	// (olaris) task [-t nuvfile.yml testcmd --]
 	// 2 <nil>
-	// (olaris) task [-t nuvfile.yml top -- arg]
+	// (olaris) task [-t nuvfile.yml testcmd -- arg]
 	// 3 <nil>
-	// (olaris) task [-t nuvfile.yml top VAR=1 -- arg]
+	// (olaris) task [-t nuvfile.yml testcmd VAR=1 -- arg]
 	// 4 <nil>
-	// (olaris) task [-t nuvfile.yml top VAR=1 -- arg]
+	// (olaris) task [-t nuvfile.yml testcmd VAR=1 -- arg]
 	//5 <nil>
 }
 
@@ -112,8 +114,8 @@ func Test_getTaskNamesList(t *testing.T) {
 			t.Fatalf("expected 2 tasks, got %d", len(tasks))
 		}
 
-		if tasks[0] != "task1" || tasks[1] != "task2" {
-			t.Fatalf("expected task1 and task2, got %s and %s", tasks[0], tasks[1])
+		if !slices.Contains(tasks, "task1") || !slices.Contains(tasks, "task2") {
+			t.Fatalf("expected task1 and task2, got %v", tasks)
 		}
 	})
 

--- a/nuv_test.go
+++ b/nuv_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"testing"
 )
 
 func ExampleNuvArg() {
@@ -90,4 +91,47 @@ func ExampleParseArgs() {
 	// 2 [__fa=false __fb=false __fl= __help=false __version=false _c=true _h=false _name_=('mike') _x_= _y_= arg1=false arg2=false arg3=false args=true hello=false opt1=false opt2=false]
 	// 3 [__fa=false __fb=false __fl=3 __help=false __version=false _c=false _h=false _name_=('max') _x_=1 _y_=2 arg1=true arg2=true arg3=false args=false hello=false opt1=false opt2=false]
 	// 4 [__fa=false __fb=true __fl= __help=false __version=false _c=false _h=false _name_=() _x_=4 _y_=5 arg1=false arg2=false arg3=true args=false hello=false opt1=false opt2=true]
+}
+
+func Test_getTaskNamesList(t *testing.T) {
+	t.Run("empty nuvfile should return empty array", func(t *testing.T) {
+		tmpDir := createTmpNuvfile(t, "")
+
+		tasks := getTaskNamesList(tmpDir)
+		if len(tasks) != 0 {
+			t.Fatalf("expected 0 tasks, got %d", len(tasks))
+		}
+	})
+
+	t.Run("should return array of task names if tasks in nuvfile", func(t *testing.T) {
+		tmpDir := createTmpNuvfile(t, "tasks:\n  task1: a\n  task2: b\n")
+		defer os.RemoveAll(tmpDir)
+
+		tasks := getTaskNamesList(tmpDir)
+		if len(tasks) != 2 {
+			t.Fatalf("expected 2 tasks, got %d", len(tasks))
+		}
+
+		if tasks[0] != "task1" || tasks[1] != "task2" {
+			t.Fatalf("expected task1 and task2, got %s and %s", tasks[0], tasks[1])
+		}
+	})
+
+}
+
+func createTmpNuvfile(t *testing.T, content string) string {
+	t.Helper()
+	// create temp folder with nuvfile.yml
+	tmpDir, err := os.MkdirTemp("", "nuv-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create nuvfile.yml
+	nuvfile := filepath.Join(tmpDir, "nuvfile.yml")
+	err = os.WriteFile(nuvfile, []byte(content), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tmpDir
 }

--- a/tests/opts.bats
+++ b/tests/opts.bats
@@ -22,16 +22,16 @@ setup() {
 }
 
 @test "help" {
-run nuv sub opts
-# just one as it is a cat of a message
-assert_line "Usage:"
-run nuv sub opts -h
-assert_line "Usage:"
-run nuv sub opts --help
-assert_line "Usage:"
-# do not check the actual version but ensure the output is not the help test
-run nuv sub opts --version
-refute_output "Usage:"
+    run nuv sub opts
+    # just one as it is a cat of a message
+    assert_line "Usage:"
+    run nuv sub opts -h
+    assert_line "Usage:"
+    run nuv sub opts --help
+    assert_line "Usage:"
+    # do not check the actual version but ensure the output is not the help test
+    run nuv sub opts --version
+    refute_output "Usage:"
 }
 
 @test "cmd" {
@@ -39,7 +39,7 @@ refute_output "Usage:"
     assert_line "hello!"
 }
 
-@test "args" { 
+@test "args" {
     run nuv sub opts args mike
     assert_line "name: mike"
     assert_line "-c: no"
@@ -60,6 +60,6 @@ refute_output "Usage:"
 @test "errors" {
     run nuv sub opts arg1
     assert_line "Usage:"
-    run nuv sub opts arg opt4
+    run nuv sub opts arg1 opt4
     assert_line "Usage:"
 }

--- a/tests/prefixes.bats
+++ b/tests/prefixes.bats
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+setup() {
+    load 'test_helper/bats-support/load'
+    load 'test_helper/bats-assert/load'
+    export NO_COLOR=1
+}
+
+@test "nuv sub invoked with prefix" {
+    run nuv sub
+    # just one as it is a cat of a message
+    assert_line "* opts:         opts test"
+    assert_line "* simple:       simple"
+
+    run nuv s
+    assert_line "* opts:         opts test"
+    assert_line "* simple:       simple"
+}
+
+@test "nuv sub simple invoked with prefixes" {
+    run nuv sub simple
+    assert_line "task: [simple] echo simple"
+    assert_line "simple"
+
+    run nuv s simple
+    assert_line "task: [simple] echo simple"
+    assert_line "simple"
+
+    run nuv s s
+    assert_line "task: [simple] echo simple"
+    assert_line "simple"
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -31,6 +31,12 @@ var tools = []string{
 	"awk", "jq", "js", "envsubst", "wsk", "ht", "mkdir",
 }
 
+func availableCmds() []string {
+	cmds := append(Utils, tools...)
+	cmds = append(cmds, "task")
+	return cmds
+}
+
 func IsTool(name string) bool {
 	if IsUtil(name) {
 		return true
@@ -104,9 +110,7 @@ func RunTool(name string, args []string) (int, error) {
 
 func Help() {
 	fmt.Println("Available tools:")
-	tools := append(Utils, tools...)
-	tools = append(tools, "task")
-	for _, x := range tools {
+	for _, x := range availableCmds() {
 		fmt.Printf("-%s\n", x)
 	}
 }


### PR DESCRIPTION
This PR closes #9 

It adds a validateTaskName function that is used when running a task. It reads the nuvfile.yml in the current directory to grab the list of task names and performs some validation to check that the input arg task is present in the list of if it is a prefix. In case it's a prefix the input arg task is swapped with the proper name. in case of ambiguity it returns an error.