### PR TITLE
Refactor js tool

### DIFF
--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func main() {
 		if tools.IsTool(cmd) {
 			code, err := tools.RunTool(cmd, args[2:])
 			if err != nil {
-				log.Print(err.Error())
+				fmt.Println(err.Error())
 			}
 			os.Exit(code)
 		}

--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func main() {
 		if tools.IsTool(cmd) {
 			code, err := tools.RunTool(cmd, args[2:])
 			if err != nil {
-				fmt.Println(err.Error())
+				log.Print(err.Error())
 			}
 			os.Exit(code)
 		}

--- a/tests/js.bats
+++ b/tests/js.bats
@@ -45,29 +45,3 @@ setup() {
     assert_line "3"
     assert_success
 }
-
-@test "-js with echo" {
-    run echo "$(echo "console.log('Hello Nuvolaris')" | nuv -js)"
-    assert_line "Hello Nuvolaris"
-    assert_success
-}
-
-# @test "-awk print $ 1 file" {
-#     run nuv -awk '{print $1}' testdata/awk_test.txt
-#     assert_line "This"
-#     assert_line "This"
-#     assert_line "This"
-#     assert_success
-# }
-
-# @test "-awk replace" {
-#     run echo "$(echo "Hello World" | nuv -awk '{$2="Nuvolaris"; print $0}')"
-#     assert_line "Hello Nuvolaris"
-#     assert_success
-# }
-
-# @test "file not found" {
-#     run nuv -awk '{print $1}' testdata/no_tests.txt
-#     assert_line "file \"testdata/no_tests.txt\" not found"
-#     assert_failure
-# }

--- a/tests/js.bats
+++ b/tests/js.bats
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+setup() {
+    load 'test_helper/bats-support/load'
+    load 'test_helper/bats-assert/load'
+    export NO_COLOR=1
+    export NUV_NO_LOG_PREFIX=1
+}
+
+@test "-js" {
+    run nuv -js
+    assert_line "Usage: nuv -js FILE.js"
+    assert_line "Interpret and run Javascript code."
+}
+
+@test "-js -h" {
+    run nuv -js -h
+    assert_line "Usage: nuv -js FILE.js"
+    assert_line "Interpret and run Javascript code."
+}
+
+@test "-js with simple file.js" {
+    run nuv -js testdata/js_simple_test.js
+    assert_line "2 + 2 = 4"
+    assert_success
+}
+
+@test "-js with js function" {
+    run nuv -js testdata/js_function_test.js
+    assert_line "3"
+    assert_success
+}
+
+@test "-js with echo" {
+    run echo "$(echo "console.log('Hello Nuvolaris')" | nuv -js)"
+    assert_line "Hello Nuvolaris"
+    assert_success
+}
+
+# @test "-awk print $ 1 file" {
+#     run nuv -awk '{print $1}' testdata/awk_test.txt
+#     assert_line "This"
+#     assert_line "This"
+#     assert_line "This"
+#     assert_success
+# }
+
+# @test "-awk replace" {
+#     run echo "$(echo "Hello World" | nuv -awk '{$2="Nuvolaris"; print $0}')"
+#     assert_line "Hello Nuvolaris"
+#     assert_success
+# }
+
+# @test "file not found" {
+#     run nuv -awk '{print $1}' testdata/no_tests.txt
+#     assert_line "file \"testdata/no_tests.txt\" not found"
+#     assert_failure
+# }

--- a/tests/testdata/js_function_test.js
+++ b/tests/testdata/js_function_test.js
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function sum(a, b) {
+    return a + b;
+}
+
+console.log(sum(1, 2));

--- a/tests/testdata/js_simple_test.js
+++ b/tests/testdata/js_simple_test.js
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+let x = 2;
+let y = 2;
+let sum = x + y;
+console.log(x + " + " + y + " = " + sum);

--- a/tools/js.go
+++ b/tools/js.go
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tools
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mattn/go-isatty"
+	goja "github.com/nuvolaris/goja/gojamain"
+)
+
+func jsToolMain() error {
+	// Define command line flags
+	helpFlag := flag.Bool("h", false, "Print help message")
+
+	// Parse command line flags
+	flag.Parse()
+
+	// Check if input is from terminal and not from a pipe
+	isTerminal := isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())
+	// if no input file and no input from pipe, print help message
+	if isTerminal && flag.NArg() == 0 {
+		printJSHelp()
+		return nil
+	}
+
+	// Print help message if -h flag is provided
+	if *helpFlag {
+		printJSHelp()
+		return nil
+	}
+
+	return goja.GojaMain()
+}
+
+func printJSHelp() {
+	fmt.Println("Usage: nuv -js FILE.js")
+	fmt.Print("Flags: -h  Print help message\n\n")
+	fmt.Println("Interpret and run Javascript code.")
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -24,7 +24,6 @@ import (
 	"github.com/nojima/httpie-go"
 	envsubst "github.com/nuvolaris/envsubst/cmd/envsubstmain"
 	"github.com/nuvolaris/goawk"
-	goja "github.com/nuvolaris/goja/gojamain"
 )
 
 var tools = []string{
@@ -91,7 +90,7 @@ func RunTool(name string, args []string) (int, error) {
 		return gojq.Run(), nil
 	case "js":
 		os.Args = append([]string{"goja"}, args...)
-		if err := goja.GojaMain(); err != nil {
+		if err := jsToolMain(); err != nil {
 			return 1, err
 		}
 	case "envsubst":


### PR DESCRIPTION
Wrap the goja tool into tools/js.go to add the `-h` flag and check if no input is given. 
The PR also adds some bats tests in `tests/js.bats` for the js tool. 

The PR is built starting from the commits in #16 so that should be merged before (it uses the no log prefix variable).