### PR TITLE
Version checking when updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The following environment variables allows to ovverride certain defaults.
 - `NUV_BRANCH` is the branch where `nuv` looks for its tasks. The branch to use is defined at build time and it is the base version (without the patch level). For example, if `nuv` is `0.3.0-morpheus` the branch to use will be `0.3-morpheus`
 - `NUV_CMD` is the actualy command executed - defaults to the absolute path of the target of the symbolic link but it can be overriden
 - `NUV_NO_LOG_PREFIX` can be defined to disable the prefix of the log messages. By default the prefix is enabled.
+- `NUV_VERSION` can be defined to set nuv's version value. It is useful to override version validations when updating tasks (and you know what you are doing). 
 
 ## Where `nuv` looks for binaries 
 

--- a/common.go
+++ b/common.go
@@ -37,6 +37,11 @@ const NUVREPO = "http://github.com/nuvolaris/olaris"
 var NuvVersion = "main"
 var NuvBranch = "main"
 
+// Represents nuvroot.json. It is used to parse the file.
+type NuvRootJSON struct {
+	Version string `json:"version"`
+}
+
 // get defaults
 
 func getNuvRoot() (string, error) {

--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func main() {
 		if tools.IsTool(cmd) {
 			code, err := tools.RunTool(cmd, args[2:])
 			if err != nil {
-				log.Print(err.Error())
+				fmt.Println(err.Error())
 			}
 			os.Exit(code)
 		}

--- a/main.go
+++ b/main.go
@@ -88,6 +88,9 @@ func main() {
 	if os.Getenv("NUV_NO_LOG_PREFIX") != "" {
 		log.SetFlags(0)
 	}
+	if os.Getenv("NUV_VERSION") != "" {
+		NuvVersion = os.Getenv("NUV_VERSION")
+	}
 
 	var err error
 	me := os.Args[0]
@@ -123,7 +126,7 @@ func main() {
 		}
 		if cmd == "update" {
 			// ok no up, nor down, let's download it
-			_, err := downloadTasksFromGitHub(true, true)
+			err := pullTasks(true, true)
 			if err != nil {
 				log.Println(err)
 				os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func main() {
 		if tools.IsTool(cmd) {
 			code, err := tools.RunTool(cmd, args[2:])
 			if err != nil {
-				fmt.Println(err.Error())
+				log.Print(err.Error())
 			}
 			os.Exit(code)
 		}

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+setup() {
+    load 'test_helper/bats-support/load'
+    load 'test_helper/bats-assert/load'
+    export NO_COLOR=1
+    export NUV_NO_LOG_PREFIX=1
+}
+
+@test "nuv -update" {
+    run nuv -update
+    assert_line "nuvfiles updated successfully"
+    assert_success
+}
+
+@test "nuv -update with old version warns" {
+    NUV_VERSION=0.2.0 run nuv -update
+    assert_line "Your nuv version 0.2.0 is older than the required version in nuvroot.json."
+    assert_line "Please update nuv to the latest version."
+    assert_line "nuvfiles updated successfully"
+    assert_success
+}
+
+@test "nuv -update with bad version" {
+    NUV_VERSION=notsemver run nuv -update
+    assert_line "Unable to validate nuv version notsemver : Invalid Semantic Version"
+    assert_line "nuvfiles updated successfully"
+    assert_success
+}
+
+@test "nuv -update with newer version" {
+    NUV_VERSION=1.2.3 run nuv -update
+    assert_line "nuvfiles updated successfully"
+    assert_success
+}


### PR DESCRIPTION
This PR closes #12 and it is based on #16 

It adds version validation when updating tasks with `nuv -update`. After downloading the tasks from github the `nuvroot.json` file is parsed and the version field is compared to the NuvVersion var using the semver package. In case of a version older than the one in nuvroot, a warning is printed to inform the user.  