### PR TITLE
Fix usage print when given unknown flag

### DIFF
--- a/tools/filetype.go
+++ b/tools/filetype.go
@@ -26,6 +26,8 @@ import (
 )
 
 func Filetype() error {
+	flag.Usage = printFiletypeHelp
+
 	// Define command line flags
 	helpFlag := flag.Bool("h", false, "Print help message")
 	extensionFlag := flag.Bool("e", false, "Show file standard extension")
@@ -36,14 +38,14 @@ func Filetype() error {
 
 	// Print help message if -h flag is provided
 	if *helpFlag {
-		printFiletypeHelp()
+		flag.Usage()
 		return nil
 	}
 
 	// Get the list of directories to create from the remaining command line arguments
 	files := flag.Args()
 	if len(files) != 1 {
-		printFiletypeHelp()
+		flag.Usage()
 		return nil
 	}
 

--- a/tools/js.go
+++ b/tools/js.go
@@ -27,6 +27,8 @@ import (
 )
 
 func jsToolMain() error {
+	flag.Usage = printJSHelp
+
 	// Define command line flags
 	helpFlag := flag.Bool("h", false, "Print help message")
 
@@ -37,13 +39,13 @@ func jsToolMain() error {
 	isTerminal := isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())
 	// if no input file and no input from pipe, print help message
 	if isTerminal && flag.NArg() == 0 {
-		printJSHelp()
+		flag.Usage()
 		return nil
 	}
 
 	// Print help message if -h flag is provided
 	if *helpFlag {
-		printJSHelp()
+		flag.Usage()
 		return nil
 	}
 

--- a/tools/mkdirs.go
+++ b/tools/mkdirs.go
@@ -24,6 +24,7 @@ import (
 )
 
 func Mkdirs() error {
+	flag.Usage = printMkdirsHelp
 	// Define command line flags
 	helpFlag := flag.Bool("h", false, "Print help message")
 	parentFlag := flag.Bool("p", false, "Create parent directories")
@@ -33,14 +34,14 @@ func Mkdirs() error {
 
 	// Print help message if -h flag is provided
 	if *helpFlag {
-		printMkdirsHelp()
+		flag.Usage()
 		return nil
 	}
 
 	// Get the list of directories to create from the remaining command line arguments
 	dirs := flag.Args()
 	if len(dirs) == 0 {
-		printMkdirsHelp()
+		flag.Usage()
 	}
 
 	// Create each directory, with or without parent directories


### PR DESCRIPTION
This PR fixes #20 

In mkdir, filetype and js tools the usage print is done with flag.Usage() which fixes the bugged usage print when passing a wrong flag.