### PR TITLE
Update taskmain use with errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/nuvolaris/openwhisk-cli/commands v0.0.0-20221227222349-fba31e174b7e
 	github.com/nuvolaris/openwhisk-cli/wski18n v0.0.0-20221227222349-fba31e174b7e
 	github.com/nuvolaris/someutils v0.0.0-20230215214008-863dfc0bf05f
-	github.com/nuvolaris/task/cmd/taskmain/v3 v3.0.0-20230216111806-00c2fce2c9af
+	github.com/nuvolaris/task/cmd/taskmain/v3 v3.0.0-20230402141038-0db2546a8eea
 )
 
 require (
@@ -58,13 +58,13 @@ require (
 	github.com/laher/uggo v0.0.0-20140418102112-0ad25fe11c5b // indirect
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/mattn/go-isatty v0.0.17
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mattn/go-zglob v0.0.4 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/mtibben/androiddnsfix v0.0.0-20200907095054-ff0280446354 // indirect
 	github.com/nuvolaris/sh/v3 v3.0.0-20230312215406-ee139db1ecdb // indirect
-	github.com/nuvolaris/task/v3 v3.9.3-0.20230216111806-00c2fce2c9af // indirect
+	github.com/nuvolaris/task/v3 v3.9.3-0.20230312223316-86b1c3692788 // indirect
 	github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3 // indirect
 	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/pjbgf/sha1cd v0.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,14 @@ github.com/nuvolaris/someutils v0.0.0-20230215214008-863dfc0bf05f h1:GGuATfUmfk+
 github.com/nuvolaris/someutils v0.0.0-20230215214008-863dfc0bf05f/go.mod h1:27LYTtM+ymckYJ+I+C5Tg6/ir+QyBQZVNN6TvlNQ1zA=
 github.com/nuvolaris/task/cmd/taskmain/v3 v3.0.0-20230216111806-00c2fce2c9af h1:qrWzfVaAS4yBxFP0ZJuSNBi8omKZwS+gzUbvYZsOKvk=
 github.com/nuvolaris/task/cmd/taskmain/v3 v3.0.0-20230216111806-00c2fce2c9af/go.mod h1:UvD9D0ygT8FAqFSC5da0eOGUww/R6p6yJ6qw1eQaE4w=
+github.com/nuvolaris/task/cmd/taskmain/v3 v3.0.0-20230402134833-85c9dab6378a h1:uaCdCLkvkErHCAsCGqnNVfdct63QT3Sns25VcUeOaOs=
+github.com/nuvolaris/task/cmd/taskmain/v3 v3.0.0-20230402134833-85c9dab6378a/go.mod h1:CTnvj/r7Fzu8FfDwmIC6xAVJAUE7I+D8pq1owkYTCqU=
+github.com/nuvolaris/task/cmd/taskmain/v3 v3.0.0-20230402141038-0db2546a8eea h1:Bf1ftpuSesgQRdf6DftDsubR0yMe4i3UhNmlyp/IsNQ=
+github.com/nuvolaris/task/cmd/taskmain/v3 v3.0.0-20230402141038-0db2546a8eea/go.mod h1:CTnvj/r7Fzu8FfDwmIC6xAVJAUE7I+D8pq1owkYTCqU=
 github.com/nuvolaris/task/v3 v3.9.3-0.20230216111806-00c2fce2c9af h1:r8abg+DyUtr6HtXhlD9fD7IRGTMyFjgbyvxufs6JmxM=
 github.com/nuvolaris/task/v3 v3.9.3-0.20230216111806-00c2fce2c9af/go.mod h1:cyE2QNqK69q5ujo/d7ikHv/Z6Y7wtpTCCIUfd0DPDC0=
+github.com/nuvolaris/task/v3 v3.9.3-0.20230312223316-86b1c3692788 h1:kdzFpKIzwwr2bcc+9RztkIS70CdNhXvZlULkZoFqygA=
+github.com/nuvolaris/task/v3 v3.9.3-0.20230312223316-86b1c3692788/go.mod h1:sIKMmkcKbJQEuFJHzfu23rs8VhnQbLoeZ98i1K75ei8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/main.go
+++ b/main.go
@@ -109,12 +109,18 @@ func main() {
 	if len(args) > 1 && len(args[1]) > 0 && args[1][0] == '-' {
 		cmd := args[1][1:]
 		if cmd == "" || cmd == "-" || cmd == "task" {
+			var params []string
+			// TODO: small hack to not have a crash when running "nuv -task"
 			if len(args) < 3 {
-				taskmain.Task(args[1:])
-				os.Exit(0)
+				params = args[1:]
+			} else {
+				params = args[2:]
 			}
-			taskmain.Task(args[2:])
-			os.Exit(0)
+			exitCode, err := taskmain.Task(params)
+			if err != nil {
+				log.Println(err)
+			}
+			os.Exit(exitCode)
 		}
 		if cmd == "info" {
 			info()
@@ -150,8 +156,7 @@ func main() {
 	// execute nuv
 	dir, err := getNuvRoot()
 	if err != nil {
-		log.Println(err)
-		os.Exit(1)
+		log.Fatalf("error: %s", err.Error())
 	}
 
 	// check if olaris was recently updated
@@ -159,7 +164,6 @@ func main() {
 	checkUpdated(parent(dir), 24*time.Hour)
 
 	if err := Nuv(dir, args[1:]); err != nil {
-		log.Println(err)
-		os.Exit(1)
+		log.Fatalf("error: %s", err.Error())
 	}
 }

--- a/nuv.go
+++ b/nuv.go
@@ -27,13 +27,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func help() {
+func help() error {
 	if exists(".", NUVOPTS) {
 		fmt.Println(readfile(NUVOPTS))
 	} else {
-		//fmt.Println("-t", "Nuvfile", "-l")
-		Task("-t", NUVFILE, "-l")
+		// In case of syntax error, Task will return an error
+		_, err := Task("-t", NUVFILE, "-l")
+		return err
 	}
+	return nil
 }
 
 // parseArgs parse the arguments acording the docopt
@@ -122,8 +124,7 @@ func Nuv(base string, args []string) error {
 	}
 
 	if len(rest) == 0 || rest[0] == "help" {
-		help()
-		return nil
+		return help()
 	}
 
 	// parsed args
@@ -136,8 +137,8 @@ func Nuv(base string, args []string) error {
 		}
 		parsedArgs = append(prefix, parsedArgs...)
 		//fmt.Println("POSTPARSE:", parsedArgs)
-		Task(parsedArgs...)
-		return nil
+		_, err := Task(parsedArgs...)
+		return err
 	}
 
 	mainTask := rest[0]
@@ -154,8 +155,8 @@ func Nuv(base string, args []string) error {
 	}
 	taskArgs := append(pre, post...)
 	debug(taskArgs)
-	Task(taskArgs...)
-	return nil
+	_, err = Task(taskArgs...)
+	return err
 }
 
 // validateTaskName does the following:

--- a/task.go
+++ b/task.go
@@ -26,12 +26,12 @@ import (
 
 var taskDryRun = false
 
-func Task(args ...string) {
+func Task(args ...string) (int, error) {
 	if taskDryRun {
 		cur, _ := os.Getwd()
 		dir := path.Base(cur)
 		fmt.Printf("(%s) task %v\n", dir, args)
-	} else {
-		taskmain.Task(append([]string{"task"}, args...))
+		return 0, nil
 	}
+	return taskmain.Task(append([]string{"task"}, args...))
 }

--- a/tests/opts.bats
+++ b/tests/opts.bats
@@ -60,6 +60,8 @@ setup() {
 @test "errors" {
     run nuv sub opts arg1
     assert_line "Usage:"
+    assert_failure
     run nuv sub opts arg1 opt4
     assert_line "Usage:"
+    assert_failure
 }


### PR DESCRIPTION
This PR closes #13

The updated taskmain returns an exitCode, error so they are now used to catch and log Task errors.