### PR TITLE
Add web server on olaris/web folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Nuv is the nuvolaris all-mighty build tool.
 
 This is a rewrite of the current build tools to make it super powerful.
 
-It is basically the [task](https://taskfile.dev) tool enanced to support:
+It is basically the [task](https://taskfile.dev) tool enhanced to support:
 
-- a bunch of embedded commands (check tooks) including `wsk` 
-- the ability to download other tools on the file
+- a bunch of embedded commands (check tools) including `wsk` 
+- the ability to download other tools
 - a predefined set of tasks downloaded from github
 - a way to create a hierarchy of taskfiles 
 - documentation for tasks powered by [docopt](http://docopt.org/)
@@ -51,13 +51,14 @@ Note that to avoid an egg and chicken problem, `nuv` itself is built with his an
 The following environment variables allows to ovverride certain defaults.
 
 - `NUV_ROOT` is the folder where `nuv` looks for its tasks. If not defined, it follows the algorithm below to find it.
-- `NUV_BIN` is the folder where `nuv` looks binaries (external command line tools). If not defined, it defaults to the same directory where  `nuv` is located.
-- `NUV_REPO` is the github repo where `nuv` downloads its tasks. If not defined, it defaults to `https://github.com/nuvolaris/olaris`
-- `NUV_BRANCH` is the branch where `nuv` looks for its tasks. The branch to use is defined at build time and it is the base version (without the patch level). For example, if `nuv` is `0.3.0-morpheus` the branch to use will be `0.3-morpheus`
-- `NUV_CMD` is the actualy command executed - defaults to the absolute path of the target of the symbolic link but it can be overriden
+- `NUV_BIN` is the folder where `nuv` looks for binaries (external command line tools). If not defined, it defaults to the same directory where  `nuv` is located.
+- `NUV_REPO` is the github repo where `nuv` downloads its tasks. If not defined, it defaults to `https://github.com/nuvolaris/olaris`.
+- `NUV_BRANCH` is the branch where `nuv` looks for its tasks. The branch to use is defined at build time and it is the base version (without the patch level). For example, if `nuv` is `0.3.0-morpheus` the branch to use will be `0.3-morpheus`.
+- `NUV_CMD` is the actual command executed - defaults to the absolute path of the target of the symbolic link but it can be overriden.
 - `NUV_VERSION` can be defined to set nuv's version value. It is useful to override version validations when updating tasks (and you know what you are doing). 
 - `NUV_NO_LOG_PREFIX` can be defined to disable the prefix of the log messages. By default the prefix is enabled.
 - `NUV_NO_NUVOPTS` can be defined to disable nuvopts parsing. Useful to test hidden tasks. When this is enabled it also shows all the tasks instead of just those with a description.
+- `NUV_PORT` is the port where `nuv` will run the web server. If not defined, it defaults to `9678`.
 
 ## Where `nuv` looks for binaries 
 
@@ -67,7 +68,7 @@ They are expected to be in the folder pointed by the environment variable `NUV_B
 
 If this environment variable is not defined, it defaults to the same folder where `nuv` itself is located. The `NUV_BIN` folder is then added to the beginning of the `PATH` before executing anything else.
 
-Nuv is  normally distributed with an installer that includes all the tools for the various operating systems (linux, windows, osx).
+Nuv is normally distributed with an installer that includes all the tools for the various operating systems (linux, windows, osx).
 
 **NOTE**: You can download the relevant tools when you run from source code executing `task install`. This task will download the command line tools and setup a link in `/usr/local/bin` to invoke `nuv`.
 
@@ -79,17 +80,17 @@ Nuv is able either to run existing tasks or download them from github.
 
 When you run `nuv [<args>...]` it will first look for its `nuv` root.
 
-The `nuv` root is a folder with two files in it: `nuvfile.yml` (an yaml taskfile) and `nuvroot.json` (a json file with release informations).
+The `nuv` root is a folder with two files in it: `nuvfile.yml` (a yaml taskfile) and `nuvroot.json` (a json file with release information).
 
 The first step is to locate the root folder. The algorithm to find the tools is the following.
 
 If the environment variable `NUV_ROOT` is defined, it will look there first, and will check if there are the two files.
 
-Then it will look in the current folder if there is a `nuvfile.yml`. If there is, it will also look for `nuvroot.json`. If it is not there, it will go up of one level looking for a directory with `nuvfile.yml` and `nuvtools.json`, and selects it as the `nuv` root.
+Then it will look in the current folder if there is a `nuvfile.yml`. If there is, it will also look for `nuvroot.json`. If it is not there, it will go up one level looking for a directory with `nuvfile.yml` and `nuvtools.json`, and selects it as the `nuv` root.
 
 If there is not a `nuvfile.yml` it will look for a folder called `olaris` with both a `nuvfile.yml` and `nuvtools.json` in it and will select it as the `nuv` root.
 
-Then it will look in `~/nuv` if there is an `olaris` folder with `nuvfile.yml` and `nuvroot.json`.
+Then it will look in `~/.nuv` if there is an `olaris` folder with `nuvfile.yml` and `nuvroot.json`.
 
 Finally it will look in the `NUV_BIN` folder if there is an `olaris` folder with  `nuvfile.yml` and `nuvroot.json`
 
@@ -101,21 +102,21 @@ Download tasks from GitHub is triggered by the `nuv -update` command.
 
 The repo to use is defined by the environment variable `NUV_REPO`, and defaults if it is missing to `https://github.com/nuvolaris/olaris`
 
-The branch to use it defined at build time. It can be overriden with the enviroment variable `NUV_BRANCH`.
+The branch to use is defined at build time. It can be overriden with the enviroment variable `NUV_BRANCH`.
 
 When you run `nuv -update`, if there is not a `~/.nuv/olaris` it will clone the current branch, otherwise it will update it.
 
 ## How `nuv` execute tasks
 
-It will then look to the command line parameters parameters `nuv <arg1> <arg2> <arg3>` and will consider them directory names. The list can be empty. 
+It will then look to the command line parameters `nuv <arg1> <arg2> <arg3>` and will consider them directory names. The list can be empty. 
 
 If there is a directory name  `<arg1>` it will change to that directory. If there is then a subdirectory `<arg2>` it will change to that and so on until it finds a argument that is not a directory name. 
 
-If the last argument is a directory name, will look for a `nuvopts.txt`. If it is there, it will show this. It is is not there it will execute a `task -t nuvfile.yml -l` showing tasks with description. 
+If the last argument is a directory name, will look for a `nuvopts.txt`. If it is there, it will show this. If it's not there, it will execute a `task -t nuvfile.yml -l` showing tasks with description. 
 
 If it finds an argument not corresponding to a directory, it will consider it a task to execute, 
 
-If there is not a `nuvopts.txt`,  it will execute as a task, passing the other arguments (equivalent to `task -t nuvfile.yml <arg> -- <the-other-args>`).
+If there is not a `nuvopts.txt`, it will execute as a task, passing the other arguments (equivalent to `task -t nuvfile.yml <arg> -- <the-other-args>`).
 
 If there is a `nuvopts.txt`, it will interpret it as a  [`docopt`](http://docopt.org/) to parse the remaining arguments as parameters. The result of parsing is a sequence of `<key>=<value>` that will be fed to `task`. So it is equivalent to invoking `task -t nuvfile.yml <arg> <key>=<value> <key>=<value>...`
 

--- a/common.go
+++ b/common.go
@@ -18,11 +18,14 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+// default port for nuv server
 
 // default files
 const NUVFILE = "nuvfile.yml"
@@ -42,8 +45,18 @@ type NuvRootJSON struct {
 	Version string `json:"version"`
 }
 
-// get defaults
+const DefaultNuvPort = 9768
 
+func getNuvPort() string {
+	port := os.Getenv("NUV_PORT")
+	if port == "" {
+		port = fmt.Sprintf("%d", DefaultNuvPort)
+	}
+	os.Setenv("NUV_PORT", port)
+	return port
+}
+
+// get defaults
 func getNuvRoot() (string, error) {
 	root := os.Getenv("NUV_ROOT")
 	if root == "" {

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3 // indirect
 	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/pjbgf/sha1cd v0.2.3 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/radovskyb/watcher v1.0.7 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/nuvolaris/sh/v3 v3.0.0-20230312215406-ee139db1ecdb h1:6IkRuVvcazBzLNG
 github.com/nuvolaris/sh/v3 v3.0.0-20230312215406-ee139db1ecdb/go.mod h1:epa2doZ4F/RIonykbbXBOsz2ciFKpn4fsOo4KrJQiGs=
 github.com/nuvolaris/someutils v0.0.0-20230406090008-39e94b70e1ae h1:r/98Ma2fvAFYBEQC2OqKsD4tI7r75N7YzhWv2ievhRA=
 github.com/nuvolaris/someutils v0.0.0-20230406090008-39e94b70e1ae/go.mod h1:27LYTtM+ymckYJ+I+C5Tg6/ir+QyBQZVNN6TvlNQ1zA=
-github.com/nuvolaris/task/cmd/taskmain/v3 v3.0.0-20230402183349-40db8d138726 h1:Q2sJ3VvGzgWelTPD3N3qjSN00LgZUphEcr7LcOWfknA=
-github.com/nuvolaris/task/cmd/taskmain/v3 v3.0.0-20230402183349-40db8d138726/go.mod h1:CTnvj/r7Fzu8FfDwmIC6xAVJAUE7I+D8pq1owkYTCqU=
+github.com/nuvolaris/task/cmd/taskmain/v3 v3.0.0-20230402141038-0db2546a8eea h1:Bf1ftpuSesgQRdf6DftDsubR0yMe4i3UhNmlyp/IsNQ=
+github.com/nuvolaris/task/cmd/taskmain/v3 v3.0.0-20230402141038-0db2546a8eea/go.mod h1:CTnvj/r7Fzu8FfDwmIC6xAVJAUE7I+D8pq1owkYTCqU=
 github.com/nuvolaris/task/v3 v3.9.3-0.20230312223316-86b1c3692788 h1:kdzFpKIzwwr2bcc+9RztkIS70CdNhXvZlULkZoFqygA=
 github.com/nuvolaris/task/v3 v3.9.3-0.20230312223316-86b1c3692788/go.mod h1:sIKMmkcKbJQEuFJHzfu23rs8VhnQbLoeZ98i1K75ei8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -313,6 +313,8 @@ github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNC
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pjbgf/sha1cd v0.2.3 h1:uKQP/7QOzNtKYH7UTohZLcjF5/55EnTw0jO/Ru4jZwI=
 github.com/pjbgf/sha1cd v0.2.3/go.mod h1:HOK9QrgzdHpbc2Kzip0Q1yi3M2MFGPADtR6HjG65m5M=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -499,6 +501,7 @@ golang.org/x/sys v0.0.0-20210304203436-1243437a8ec7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/nuvolaris/nuv/tools"
 	"github.com/nuvolaris/task/cmd/taskmain/v3"
+	"github.com/pkg/browser"
 )
 
 func setupCmd(me string) (string, error) {
@@ -160,7 +161,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	// execute nuv
 	dir, err := getNuvRoot()
 	if err != nil {
 		log.Fatalf("error: %s", err.Error())
@@ -170,7 +170,17 @@ func main() {
 	// we pass parent(dir) because we use the olaris parent folder
 	checkUpdated(parent(dir), 24*time.Hour)
 
-	if err := Nuv(dir, args[1:]); err != nil {
-		log.Fatalf("error: %s", err.Error())
+	if len(args) == 1 {
+		// run nuv server and open browser
+		port := getNuvPort()
+		go RunNuvServer(dir, port)
+		if err := browser.OpenURL("http://localhost:" + port); err != nil {
+			log.Fatal(err)
+		}
+		select {}
+	} else {
+		if err := Nuv(dir, args[1:]); err != nil {
+			log.Fatalf("error: %s", err.Error())
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -132,6 +132,9 @@ func main() {
 			tools.Help()
 			os.Exit(0)
 		}
+		if cmd == "serve" {
+			RunNuvServer(retrieveRootDir(), getNuvPort())
+		}
 		if cmd == "update" {
 			// ok no up, nor down, let's download it
 			err := pullTasks(true, true)
@@ -161,11 +164,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	dir, err := getNuvRoot()
-	if err != nil {
-		log.Fatalf("error: %s", err.Error())
-	}
-
+	dir := retrieveRootDir()
 	// check if olaris was recently updated
 	// we pass parent(dir) because we use the olaris parent folder
 	checkUpdated(parent(dir), 24*time.Hour)
@@ -183,4 +182,12 @@ func main() {
 			log.Fatalf("error: %s", err.Error())
 		}
 	}
+}
+
+func retrieveRootDir() string {
+	dir, err := getNuvRoot()
+	if err != nil {
+		log.Fatalf("error: %s", err.Error())
+	}
+	return dir
 }

--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/nuvolaris/nuv/tools"
 	"github.com/nuvolaris/task/cmd/taskmain/v3"
-	"github.com/pkg/browser"
 )
 
 func setupCmd(me string) (string, error) {
@@ -133,7 +132,10 @@ func main() {
 			os.Exit(0)
 		}
 		if cmd == "serve" {
-			RunNuvServer(retrieveRootDir(), getNuvPort())
+			if err := Serve(retrieveRootDir(), args[1:]); err != nil {
+				log.Fatalf("error: %v", err)
+			}
+			os.Exit(0)
 		}
 		if cmd == "update" {
 			// ok no up, nor down, let's download it
@@ -169,18 +171,8 @@ func main() {
 	// we pass parent(dir) because we use the olaris parent folder
 	checkUpdated(parent(dir), 24*time.Hour)
 
-	if len(args) == 1 {
-		// run nuv server and open browser
-		port := getNuvPort()
-		go RunNuvServer(dir, port)
-		if err := browser.OpenURL("http://localhost:" + port); err != nil {
-			log.Fatal(err)
-		}
-		select {}
-	} else {
-		if err := Nuv(dir, args[1:]); err != nil {
-			log.Fatalf("error: %s", err.Error())
-		}
+	if err := Nuv(dir, args[1:]); err != nil {
+		log.Fatalf("error: %s", err.Error())
 	}
 }
 

--- a/prepare.go
+++ b/prepare.go
@@ -59,10 +59,10 @@ func downloadTasksFromGitHub(force bool, silent bool) (string, error) {
 
 		// Pull the latest changes from the origin remote and merge into the current branch
 		err = w.Pull(&git.PullOptions{RemoteName: "origin"})
-		if err.Error() == "already up-to-date" {
-			return localDir, nil
-		}
 		if err != nil {
+			if err.Error() == "already up-to-date" {
+				return localDir, nil
+			}
 			return "", err
 		}
 		return localDir, nil

--- a/serve.go
+++ b/serve.go
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+var WebDir = "web"
+
+func RunNuvServer(dir string, port string) {
+	web_dir := joinpath(dir, WebDir)
+	handler := nuvServerHandler(web_dir)
+	addr := fmt.Sprintf(":%s", port)
+	log.Println("Nuvolaris server started at http://localhost:" + port)
+	if err := http.ListenAndServe(addr, handler); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func nuvServerHandler(web_dir string) http.Handler {
+	return http.FileServer(http.Dir(web_dir))
+}

--- a/serve_test.go
+++ b/serve_test.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package main
 
 import (

--- a/serve_test.go
+++ b/serve_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIndex(t *testing.T) {
+	handler := nuvServerHandler(joinpath("tests/olaris/", WebDir))
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	newreq := func(method, url string, body io.Reader) *http.Request {
+		r, err := http.NewRequest(method, url, body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return r
+	}
+
+	tests := []struct {
+		name string
+		r    *http.Request
+	}{
+		{name: "1: testing get", r: newreq("GET", ts.URL+"/", nil)},
+		// {name: "2: testing post", r: newreq("POST", ts.URL+"/", nil)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := http.DefaultClient.Do(tt.r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("expected status OK; got %v", resp.Status)
+			}
+			resp.Body.Close()
+		})
+	}
+
+}

--- a/serve_test.go
+++ b/serve_test.go
@@ -21,11 +21,15 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
 func TestIndex(t *testing.T) {
-	handler := nuvServerHandler(joinpath("tests/olaris/", WebDir))
+	os.Chdir(workDir)
+	olaris, _ := filepath.Abs(joinpath("tests", "olaris"))
+	handler := nuvServerHandler(joinpath(olaris, WebDir))
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 

--- a/serve_test.go
+++ b/serve_test.go
@@ -61,5 +61,4 @@ func TestIndex(t *testing.T) {
 			resp.Body.Close()
 		})
 	}
-
 }

--- a/tests/olaris/web/index.html
+++ b/tests/olaris/web/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+
+<body>
+    <h1>Hello, Nuv.</h1>
+
+</body>
+
+</html>

--- a/tests/olaris/web/index.html
+++ b/tests/olaris/web/index.html
@@ -1,3 +1,22 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
 <!DOCTYPE html>
 <html lang="en">
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -32,7 +32,8 @@ var tools = []string{
 
 func availableCmds() []string {
 	cmds := append(Utils, tools...)
-	cmds = append(cmds, "task")
+	extra_cmds := []string{"update", "serve", "help", "info", "version", "task"}
+	cmds = append(cmds, extra_cmds...)
 	return cmds
 }
 
@@ -72,7 +73,6 @@ func RunTool(name string, args []string) (int, error) {
 		if err := Wsk(cmd); err != nil {
 			return 1, err
 		}
-		return 0, nil
 	case "ht":
 		//fmt.Println("=== ht ===")
 		os.Args = append([]string{"ht"}, args...)


### PR DESCRIPTION
This PR adds the '-serve' command to start a http.FileServer on the olaris/web folder. It also adds the browser package to start the server and open the browser on http://localhost:9678. The default port is 9678 but it can be changed with NUV_PORT env var.

closes https://github.com/nuvolaris/nuvolaris/issues/159