### PR TITLE
Refactor action and add shields in README

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,17 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: License Check
+name: Checks
 on: 
   push:
     branches:
     - '*'
     tags-ignore:
     - '*'
+  pull_request:
+    branches:
+    - 'main'
+
 
 jobs:
-  check:
-    name: Check
+  license-check:
+    name: License Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout recursive
@@ -34,6 +38,15 @@ jobs:
           submodules: recursive
       - name: License check
         uses: apache/skywalking-eyes/header@501a28d2fb4a9b962661987e50cf0219631b32ff
+      
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout recursive
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.19.0'

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
   ~ under the License.
   ~
 -->
+
+![example workflow](https://github.com/nuvolaris/nuv/actions/workflows/check.yml/badge.svg) ![Nuv Latest Release](https://badgen.net/github/release/nuvolaris/nuv/stable) ![License](https://badgen.net/github/license/nuvolaris/nuv) 
+
 **WARNING: this is still work in progress**
 
 The code may not build, there can be errors that will destroy your hard disk and so on.


### PR DESCRIPTION
This PR updates the check action by separating the license check and go test in 2 jobs that are also run on PRs and adds some badges in the README.