### PR TITLE
Consider subfolders with nuvfile as candidates

### DIFF
--- a/tests/folders.bats
+++ b/tests/folders.bats
@@ -45,7 +45,10 @@ setup() {
     assert_line simple
 }
 
-@test "other" {
+@test "other with shortening" {
+    run nuv o
+    assert_line "* simple:       simple task in other"
+
     run nuv o s
     assert_line "hidden"
 }

--- a/tests/folders.bats
+++ b/tests/folders.bats
@@ -23,6 +23,8 @@ setup() {
 
 @test "welcome" {
     run nuv
+    assert_line '* fail_then_succeed:       fail then success'
+    assert_line '* failing:                 failing'
     assert_line '* sub:                     sub command'
     assert_line '* testcmd:                 test nuv commands'
 }
@@ -41,4 +43,9 @@ setup() {
 @test "sub simple" {
     run nuv sub simple
     assert_line simple
+}
+
+@test "other" {
+    run nuv o s
+    assert_line "hidden"
 }

--- a/tests/olaris/other/nuvfile.yml
+++ b/tests/olaris/other/nuvfile.yml
@@ -19,5 +19,6 @@ version: "3"
 
 tasks:
   simple:
+    desc: simple task in other
     cmds:
       - echo hidden

--- a/tests/olaris/other/nuvfile.yml
+++ b/tests/olaris/other/nuvfile.yml
@@ -15,34 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
 version: "3"
+
 tasks:
-  other:
-
-  sub:
-    desc: sub command
-
-  testcmd:
-    desc: test nuv commands
+  simple:
     cmds:
-      - ht 2>&1 | wc -l
-
-  failing:
-    desc: failing
-    cmds:
-      - exit 1
-
-  fail_then_succeed:
-    desc: fail then success
-    cmds:
-      - ../test_helper/fail_then_succeed.sh
-
-  grep:
-    silent: true
-    cmds:
-      - |
-        if grep {{.GREP}} grep.txt
-        then echo OK
-        else echo KO
-        fi
+      - echo hidden


### PR DESCRIPTION
This PR closes https://github.com/nuvolaris/nuvolaris/issues/165 

It now also picks up subfolders with a nuvfile.yml inside as tasks that are not in the root nuvfile.yml