### PR TITLE
create check file only in home dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -173,6 +173,7 @@ func main() {
 	}
 
 	dir := retrieveRootDir()
+
 	// check if olaris was recently updated
 	// we pass parent(dir) because we use the olaris parent folder
 	checkUpdated(parent(dir), 24*time.Hour)

--- a/prepare.go
+++ b/prepare.go
@@ -84,9 +84,10 @@ func downloadTasksFromGitHub(force bool, silent bool) (string, error) {
 		return "", err
 	}
 
-	createLatestCheckFile(parent(localDir))
-
 	fmt.Println("Nuvfiles downloaded successfully")
+
+	createLatestCheckFile(nuvDir)
+
 	// clone
 	return localDir, nil
 }

--- a/updates_check_test.go
+++ b/updates_check_test.go
@@ -69,7 +69,7 @@ func Example_checkUpdated_uptodate() {
 	)
 
 	// run checkUpdated and check if it creates the latest_check file
-	checkUpdated(tmpDir, 1*time.Second)
+	createLatestCheckFile(tmpDir)
 
 	if exists(tmpDir, ".latestcheck") {
 		pr("latest_check file created")
@@ -103,7 +103,7 @@ func Example_checkUpdated_outdated() {
 	)
 
 	// run checkUpdated and check if it creates the latest_check file
-	checkUpdated(tmpDir, 1*time.Second)
+	createLatestCheckFile(tmpDir)
 
 	if exists(tmpDir, ".latestcheck") {
 		pr("latest_check file created")


### PR DESCRIPTION
This PR closes https://github.com/nuvolaris/nuvolaris/issues/182

It moves the creation of the .latestcheck file only when downloading tasks from github the first time in the ~/nuv folder.