### PR TITLE
Add -random tool

### DIFF
--- a/tests/random.bats
+++ b/tests/random.bats
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+setup() {
+    load 'test_helper/bats-support/load'
+    load 'test_helper/bats-assert/load'
+    export NO_COLOR=1
+    export NUV_NO_LOG_PREFIX=1
+}
+
+@test "nuv -random help" {
+    run nuv -random -h
+    assert_success
+    assert_line "Usage:"
+
+    run nuv -random --help
+    assert_success
+    assert_line "Usage:"
+}
+
+@test "nuv -random" {
+    run nuv -random
+    assert_success
+    refute_line "Usage:"
+}
+
+@test "nuv -random --int" {
+    run nuv -random --int
+    assert_line "Usage:"
+
+    run nuv -random --int aa
+    assert_line "Usage:"
+
+    run nuv -random --int 1 2 3
+    assert_line "Usage:"
+
+    run nuv -random --int 1 aa
+    assert_failure
+
+    run nuv -random --int -1
+    assert_failure
+
+    run nuv -random --int 0
+    assert_failure
+
+    run nuv -random --int 10 20
+    assert_failure
+
+    run nuv -random --int 10 1
+    assert_success
+}
+
+@test "nuv -random -str" {
+    run nuv -random --str
+    assert_line "Usage:"
+
+    run nuv -random --str aa
+    assert_line "Usage:"
+
+    run nuv -random --str 1 2 3
+    assert_line "Usage:"
+
+    run nuv -random --str -1
+    assert_failure
+
+    run nuv -random --str 1 aa
+    assert_success
+}
+
+@test "nuv -random -u" {
+    run nuv -random -u
+    assert_success
+
+    run nuv -random --uuid
+    assert_success
+}
+    

--- a/tools/random.go
+++ b/tools/random.go
@@ -1,42 +1,169 @@
 package tools
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
 )
 
-func RandomGenerator() {
+const defaultCharRange = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+type randomGenerator interface {
+	GenerateFloat01()
+	GenerateString(length int, chars string)
+	GenerateInteger(min, max int)
+	GenerateUUID() error
+}
+
+type randomGeneratorImpl struct{}
+
+var randomGen randomGenerator = randomGeneratorImpl{}
+
+func (r randomGeneratorImpl) GenerateFloat01() {
+	fmt.Println(rand.Float64())
+}
+
+func (r randomGeneratorImpl) GenerateString(length int, chars string) {
+	var buf bytes.Buffer
+
+	for i := 0; i < length; i++ {
+		randIndex := rand.Intn(len(chars))
+		randChar := chars[randIndex]
+		buf.WriteByte(randChar)
+	}
+
+	fmt.Println(buf.String())
+}
+
+func (r randomGeneratorImpl) GenerateInteger(min, max int) {
+	fmt.Println(rand.Intn(max-min) + min)
+}
+
+func (r randomGeneratorImpl) GenerateUUID() error {
+	uuid, err := uuid.NewRandom()
+	if err != nil {
+		return err
+	}
+	fmt.Println(uuid.String())
+	return nil
+}
+
+func RandTool() error {
 	flag.Usage = printRandomGeneratorHelp
 
+	var helpFlag bool
+	var intFlag int
+	var strFlag int
+	var uuidFlag bool
+
 	// Define command line flags
-	helpFlag := flag.Bool("h", false, "Print help message")
-	// integerFlag := flag.Bool("i", false, "Generate a random integer")
-	// stringFlag := flag.Bool("s", false, "Generate a random string")
-	// uuidFlag := flag.Bool("u", false, "Generate a random uuid v4")
+	flag.BoolVar(&helpFlag, "h", false, "Show help message")
+	flag.BoolVar(&helpFlag, "help", false, "Show help message")
+	flag.IntVar(&intFlag, "int", -1, "Generate a random integer")
+	flag.IntVar(&strFlag, "str", -1, "Generate a random string")
+	flag.BoolVar(&uuidFlag, "u", false, "Generate a random uuid")
+	flag.BoolVar(&uuidFlag, "uuid", false, "Generate a random uuid")
 
 	// Parse command line flags
 	flag.Parse()
+	args := flag.Args()
 
 	// Print help message if -h flag is provided
-	if *helpFlag {
+	if helpFlag {
 		flag.Usage()
-		return
+		return nil
+	}
+
+	rand.Seed(time.Now().UnixNano()) // Seed the random number generator with the current time
+
+	if uuidFlag {
+		return randomGen.GenerateUUID()
+	}
+
+	if isFlagPassed("int") {
+		if len(args) > 1 {
+			flag.Usage()
+			return nil
+		}
+
+		max := intFlag
+		min := 0
+
+		if max <= 0 {
+			return fmt.Errorf("invalid max value: %v. Must be greater than 0", max)
+		}
+
+		if len(args) == 1 {
+			minOpt, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+
+			min = minOpt
+		}
+
+		if min >= max {
+			return fmt.Errorf("invalid min value: %v. Must be less than max value: %v", min, max)
+		}
+
+		randomGen.GenerateInteger(min, max)
+		return nil
+	}
+
+	if isFlagPassed("str") {
+		if len(args) > 1 {
+			flag.Usage()
+			return nil
+		}
+
+		length := strFlag
+		chars := defaultCharRange
+
+		if length <= 0 {
+			return fmt.Errorf("invalid length value: %v. Must be greater than 0", length)
+		}
+
+		if len(args) == 1 {
+			chars = args[0]
+		}
+
+		randomGen.GenerateString(length, chars)
+		return nil
 	}
 
 	// Get remaining args
-	args := flag.Args()
-	if len(args) != 1 {
+	if len(args) != 0 {
 		flag.Usage()
-		return
+		return nil
 	}
 
+	randomGen.GenerateFloat01()
+	return nil
+}
+
+func isFlagPassed(name string) bool {
+	found := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+	return found
 }
 
 func printRandomGeneratorHelp() {
-	fmt.Println("Usage: random [options]")
-	fmt.Println("Generates random numbers, strings and uuids")
-	fmt.Println(" -h  shows this help")
-	fmt.Println(" -i  <max> [min] generates a random integer between min and max (default min=0)")
-	fmt.Println(" -s  <len> [<characters>] generates an alphanumeric string of length <len> from the set of <characters> provided (default <characters>=a-zA-Z0-9)")
-	fmt.Println(" -u  generates a random uuid v4")
+	fmt.Print(`Usage:
+random [options]
+Generates random numbers, strings and uuids
+
+-h, --help  shows this help
+-u, --uuid  generates a random uuid v4
+--int  <max> [min] generates a random non-negative integer between min and max (default min=0)
+--str  <len> [<characters>] generates an alphanumeric string of length <len> from the set of <characters> provided (default <characters>=a-zA-Z0-9)
+`)
 }

--- a/tools/random.go
+++ b/tools/random.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package tools
 
 import (

--- a/tools/random.go
+++ b/tools/random.go
@@ -1,0 +1,42 @@
+package tools
+
+import (
+	"flag"
+	"fmt"
+)
+
+func RandomGenerator() {
+	flag.Usage = printRandomGeneratorHelp
+
+	// Define command line flags
+	helpFlag := flag.Bool("h", false, "Print help message")
+	// integerFlag := flag.Bool("i", false, "Generate a random integer")
+	// stringFlag := flag.Bool("s", false, "Generate a random string")
+	// uuidFlag := flag.Bool("u", false, "Generate a random uuid v4")
+
+	// Parse command line flags
+	flag.Parse()
+
+	// Print help message if -h flag is provided
+	if *helpFlag {
+		flag.Usage()
+		return
+	}
+
+	// Get remaining args
+	args := flag.Args()
+	if len(args) != 1 {
+		flag.Usage()
+		return
+	}
+
+}
+
+func printRandomGeneratorHelp() {
+	fmt.Println("Usage: random [options]")
+	fmt.Println("Generates random numbers, strings and uuids")
+	fmt.Println(" -h  shows this help")
+	fmt.Println(" -i  <max> [min] generates a random integer between min and max (default min=0)")
+	fmt.Println(" -s  <len> [<characters>] generates an alphanumeric string of length <len> from the set of <characters> provided (default <characters>=a-zA-Z0-9)")
+	fmt.Println(" -u  generates a random uuid v4")
+}

--- a/tools/random_test.go
+++ b/tools/random_test.go
@@ -1,0 +1,91 @@
+package tools
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+)
+
+type fakeRandomGenerator struct {
+	w          io.Writer
+	fakeFloat  float64
+	fakeString string
+	fakeInt    int
+	fakeUUID   string
+}
+
+func (r fakeRandomGenerator) GenerateFloat01() {
+	fmt.Fprint(r.w, r.fakeFloat)
+}
+
+func (r fakeRandomGenerator) GenerateString(len int, chars string) {
+	fmt.Fprint(r.w, r.fakeString)
+}
+
+func (r fakeRandomGenerator) GenerateInteger(min, max int) {
+	fmt.Fprint(r.w, r.fakeInt)
+}
+
+func (r fakeRandomGenerator) GenerateUUID() error {
+	fmt.Fprint(r.w, r.fakeUUID)
+	return nil
+}
+
+func TestRandom(t *testing.T) {
+	oldRandomGen := randomGen
+	defer func() {
+		randomGen = oldRandomGen
+	}()
+
+	var output bytes.Buffer
+	randomGen = fakeRandomGenerator{
+		w:          &output,
+		fakeFloat:  0.5,
+		fakeString: "fakeString",
+		fakeInt:    15,
+		fakeUUID:   "fakeUUID",
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+		err  error
+	}{
+		{"float", []string{}, "0.5", nil},
+		{"uuid", []string{"--uuid"}, "fakeUUID", nil},
+		{"uuid", []string{"-u"}, "fakeUUID", nil},
+		{"int with max", []string{"--int", "10"}, "15", nil},
+		{"int with min and max", []string{"--int", "20", "10"}, "15", nil},
+		{"string with length", []string{"--str", "10"}, "fakeString", nil},
+		{"string with length and chars", []string{"--str", "10", "abc"}, "fakeString", nil},
+		//
+		{"int with invalid max", []string{"--int", "0"}, "", fmt.Errorf("invalid max value: 0. Must be greater than 0")},
+		{"int with negative max", []string{"--int", "-1"}, "", fmt.Errorf("invalid max value: -1. Must be greater than 0")},
+		{"int with min > max", []string{"--int", "10", "20"}, "", fmt.Errorf("invalid min value: 20. Must be less than max value: 10")},
+		{"string with invalid length", []string{"--str", "0"}, "", fmt.Errorf("invalid length value: 0. Must be greater than 0")},
+		{"string with negative length", []string{"--str", "-1"}, "", fmt.Errorf("invalid length value: -1. Must be greater than 0")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Args = append([]string{"random"}, tt.args...)
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError) //flags are now reset
+			flag.CommandLine.SetOutput(&output)
+
+			err := RandTool()
+			if err != nil && err.Error() != tt.err.Error() {
+				t.Errorf("RandTool() error = %v, wantErr %v", err, tt.err)
+			}
+
+			got := output.String()
+			if got != tt.want {
+				t.Errorf("RandTool() = %v, want %v", got, tt.want)
+			}
+			output.Reset()
+		})
+	}
+}

--- a/tools/random_test.go
+++ b/tools/random_test.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package tools
 
 import (

--- a/tools/retry.go
+++ b/tools/retry.go
@@ -29,7 +29,7 @@ import (
 
 func ExpBackoffRetry(args []string) error {
 	// Define command line flags
-	flag.Usage = func() { fmt.Print(usage) }
+	flag.Usage = printRetryHelp
 
 	var helpFlag bool
 	var triesFlag int
@@ -95,10 +95,13 @@ func retry(fn func([]string) error, args []string, maxTime int, maxRetries int) 
 	return nil
 }
 
-const usage = `Usage:
+func printRetryHelp() {
+	fmt.Print(
+		`Usage:
 nuv -retry [options] task [task options]
 -h, --help	Print help message
 -t, --tries=#	Set max retries: Default 10
 -m, --max=secs	Maximum time to run (set to 0 to disable): Default 60 seconds
 -v, --verbose	Verbose output
-`
+`)
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -27,12 +27,12 @@ import (
 )
 
 var tools = []string{
-	"awk", "jq", "js", "envsubst", "wsk", "ht", "mkdir", "filetype", "retry",
+	"awk", "jq", "js", "envsubst", "wsk", "ht", "mkdir", "filetype", "random",
 }
 
 func availableCmds() []string {
 	cmds := append(Utils, tools...)
-	extra_cmds := []string{"update", "serve", "help", "info", "version", "task"}
+	extra_cmds := []string{"update", "serve", "help", "info", "version", "retry", "task"}
 	cmds = append(cmds, extra_cmds...)
 	return cmds
 }
@@ -108,6 +108,9 @@ func RunTool(name string, args []string) (int, error) {
 		if err := Filetype(); err != nil {
 			return 1, err
 		}
+	case "random":
+		os.Args = append([]string{"random"}, args...)
+		RandomGenerator()
 	}
 	return 0, nil
 }

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -110,7 +110,9 @@ func RunTool(name string, args []string) (int, error) {
 		}
 	case "random":
 		os.Args = append([]string{"random"}, args...)
-		RandomGenerator()
+		if err := RandTool(); err != nil {
+			return 1, err
+		}
 	}
 	return 0, nil
 }


### PR DESCRIPTION
This PR closes https://github.com/nuvolaris/nuvolaris/issues/177

It adds the `nuv -random` tool that can be used to generate floats, ints in ranges, strings and uuids.

The flags are:
-  `-u` or `--uuid` for uuids v4.
- `--int` to generate integers
- `--str` to generate strings
- no flags to generate a float between 0-1
