### PR TITLE
Merge config keys maps

### DIFF
--- a/tests/config.bats
+++ b/tests/config.bats
@@ -38,7 +38,6 @@ setup() {
 @test "set simple var in config.json" {
     run rm -f ~/.nuv/config.json
     run nuv -config KEY=VALUE
-    assert_line "Config updated"
     assert_success
     run cat ~/.nuv/config.json
     assert_line '  "key": "VALUE"'
@@ -47,7 +46,6 @@ setup() {
 @test "set complex var in config.json" {
     run rm -f ~/.nuv/config.json
     run nuv -config KEY='{"a": 1}'
-    assert_line "Config updated"
     assert_success
     run cat ~/.nuv/config.json
     assert_line '  "key": {'
@@ -58,7 +56,6 @@ setup() {
 @test "set multiple keys in config.json" {
     run rm -f ~/.nuv/config.json
     run nuv -config KEY_NESTED=123 KEY_SIMPLE=abc
-    assert_line "Config updated"
     assert_success
     run cat ~/.nuv/config.json
     assert_line '  "key": {'
@@ -70,13 +67,11 @@ setup() {
 @test "replace existing key in config.json" {
     run rm -f ~/.nuv/config.json
     run nuv -config KEY=VALUE
-    assert_line "Config updated"
     assert_success
     run cat ~/.nuv/config.json
     assert_line '  "key": "VALUE"'
 
     run nuv -config KEY=NEW_VALUE
-    assert_line "Config updated"
     assert_success
     run cat ~/.nuv/config.json
     assert_line '  "key": "NEW_VALUE"'
@@ -85,13 +80,11 @@ setup() {
 @test "replace existing key with different type" {
     run rm -f ~/.nuv/config.json
     run nuv -config KEY=VALUE
-    assert_line "Config updated"
     assert_success
     run cat ~/.nuv/config.json
     assert_line '  "key": "VALUE"'
 
     run nuv -config KEY='{"a": 1}'
-    assert_line "Config updated"
     assert_success
     run cat ~/.nuv/config.json
     assert_line '  "key": {'
@@ -103,15 +96,28 @@ setup() {
 @test "add keys to existing config.json" {
     run rm -f ~/.nuv/config.json
     run nuv -config KEY=VALUE
-    assert_line "Config updated"
     assert_success
     run cat ~/.nuv/config.json
     assert_line '  "key": "VALUE"'
 
     run nuv -config ANOTHER=123
-    assert_line "Config updated"
     assert_success
     run cat ~/.nuv/config.json
     assert_line '  "another": 123,'
     assert_line '  "key": "VALUE"'
+}
+
+@test "merge object keys" {
+    run rm -f ~/.nuv/config.json
+    run nuv -config NESTED_KEY=123
+    assert_success
+
+    run nuv -config NESTED_ANOTHER=456
+    assert_success
+
+    run cat ~/.nuv/config.json
+    assert_line '  "nested": {'
+    assert_line '    "another": 456,'
+    assert_line '    "key": 123'
+    assert_line '  }'   
 }

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -33,7 +33,7 @@ var tools = []string{
 }
 
 // not available in taskfiles
-var extra_tools = []string{
+var extraTools = []string{
 	"update", "serve", "help", "info", "version", "task",
 }
 
@@ -119,7 +119,7 @@ func RunTool(name string, args []string) (int, error) {
 
 func Help() {
 	fmt.Println("Available tools:")
-	for _, x := range append(tools, extra_tools...) {
+	for _, x := range append(tools, extraTools...) {
 		fmt.Printf("-%s\n", x)
 	}
 }


### PR DESCRIPTION
This PR fixes the bug indicated in https://github.com/nuvolaris/nuvolaris/issues/189

Now when multiple keys that define maps are set, they don't overwrite each other but are merged