### PR TITLE
Add --dump flag to config tool

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -231,7 +231,7 @@ func Test_buildConfigObject(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := buildConfigObject(tc.input)
 
-			if tc.err != nil && (err == nil || err.Error() != tc.err.Error()) {
+			if tc.err != nil && err == nil {
 				t.Errorf("Expected error %v, got %v", tc.err, err)
 			}
 

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -121,3 +121,14 @@ setup() {
     assert_line '    "key": 123'
     assert_line '  }'   
 }
+
+@test "dump configs" {
+    run rm -f ~/.nuv/config.json
+    run nuv -config KEY=VALUE ANOTHER=123
+    assert_success
+
+    run nuv -config --dump
+    assert_success
+    assert_line 'KEY=VALUE'
+    assert_line 'ANOTHER=123'
+}


### PR DESCRIPTION
This PR closes https://github.com/nuvolaris/nuvolaris/issues/189

It adds a flag to the config tool `--dump` and shorthand `-d` to print all env vars in nuvroot.json and config.json