### PR TITLE
implement https://github.com/nuvolaris/nuvolaris/issues/203

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -26,6 +26,35 @@ import (
 	"testing"
 )
 
+func ExampleConfigTool_readValue() {
+	tmpDir, _ := os.MkdirTemp("", "nuv")
+	defer os.RemoveAll(tmpDir)
+
+	err := runConfigTool([]string{"foo=bar"}, tmpDir, false)
+	if err != nil {
+		pr("error:", err)
+	}
+
+	err = runConfigTool([]string{"foo"}, tmpDir, false)
+	if err != nil {
+		pr("error:", err)
+	}
+
+	// nested key
+	err = runConfigTool([]string{"nested_val=val"}, tmpDir, false)
+	if err != nil {
+		pr("error:", err)
+	}
+
+	err = runConfigTool([]string{"nested_val"}, tmpDir, false)
+	if err != nil {
+		pr("error:", err)
+	}
+	// Output:
+	// bar
+	// val
+}
+
 func Test_runConfigTool(t *testing.T) {
 	t.Run("new config.json", func(t *testing.T) {
 		tmpDir, _ := os.MkdirTemp("", "nuv")
@@ -199,8 +228,8 @@ func Test_runConfigTool(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 
 		err := runConfigTool([]string{"foo"}, tmpDir, true)
-		if err != nil {
-			t.Errorf("error: %v", err)
+		if err == nil {
+			t.Errorf("expected error, got nil")
 		}
 
 		got, err := readNuvConfigFile(tmpDir)
@@ -214,7 +243,6 @@ func Test_runConfigTool(t *testing.T) {
 			t.Errorf("got %v, want %v", got, want)
 		}
 	})
-
 }
 
 func Test_buildConfigObject(t *testing.T) {

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -169,3 +169,21 @@ setup() {
     run cat ~/.nuv/config.json
     assert_line '{}'
 }
+
+@test "read single value" {
+    run rm -f ~/.nuv/config.json
+    run nuv -config KEY=VALUE
+    assert_success
+
+    run nuv -config KEY
+    assert_success
+    assert_line 'VALUE'
+
+    # read nested value
+    run nuv -config NESTED_KEY=new_value
+    assert_success
+
+    run nuv -config NESTED_KEY
+    assert_success
+    assert_line 'new_value'
+}

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -186,4 +186,10 @@ setup() {
     run nuv -config NESTED_KEY
     assert_success
     assert_line 'new_value'
+
+    # read multiple values
+    run nuv -config KEY NESTED_KEY
+    assert_success
+    assert_line 'VALUE'
+    assert_line 'new_value'   
 }


### PR DESCRIPTION
This PR closes https://github.com/nuvolaris/nuvolaris/issues/203

The `nuv -config` tool can now read the values of keys in config.json by passing keys (without "=")