### PR TITLE
update plugin repo when already existing

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -67,9 +67,29 @@ func downloadPluginTasksFromRepo(repo string) error {
 		return err
 	}
 
-	// TODO if already exists, update
 	if _, err := os.Stat(pluginDir); !os.IsNotExist(err) {
-		fmt.Println("Plugin already installed:", repoName)
+		fmt.Println("Updating plugin", repoName)
+
+		r, err := git.PlainOpen(pluginDir)
+		if err != nil {
+			return err
+		}
+		// Get the working directory for the repository
+		w, err := r.Worktree()
+		if err != nil {
+			return err
+		}
+
+		// Pull the latest changes from the origin remote and merge into the current branch
+		err = w.Pull(&git.PullOptions{RemoteName: "origin"})
+		if err != nil {
+			if err.Error() == "already up-to-date" {
+				fmt.Println("The plugin repo is already up to date!")
+				return nil
+			}
+			return err
+		}
+
 		return nil
 	}
 

--- a/tests/plugin.bats
+++ b/tests/plugin.bats
@@ -74,3 +74,13 @@ setup() {
 
     run rm -rf ~/.nuv/olaris-test
 }
+
+@test "nuv -plugin on existing plugin will update it" {
+    run nuv -plugin https://github.com/giusdp/olaris-test.git
+    assert_success
+
+    run nuv -plugin https://github.com/giusdp/olaris-test.git
+    assert_success
+    assert_line "Updating plugin olaris-test"
+    assert_line "The plugin repo is already up to date!"
+}


### PR DESCRIPTION
This PR implements the plugin update by running `nuv -plugin <repo>` with an existing plugin repo