### PR TITLE
Login add user secrets to config

### DIFF
--- a/config/config_map.go
+++ b/config/config_map.go
@@ -20,6 +20,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -39,8 +40,9 @@ import (
 //		},
 //	}
 //
-// To interact with the ConfigMap, use the Insert, Get, Update, and Delete by passing
-// keys in the form above.
+// To interact with the ConfigMap, use the Insert, Get, and Delete by passing
+// keys in the form above. Only the config map is modified by these functions.
+// The nuvRootConfig map is only used to read the config keys in nuvroot.json.
 type ConfigMap struct {
 	nuvRootConfig map[string]interface{}
 	config        map[string]interface{}
@@ -122,6 +124,15 @@ func (c *ConfigMap) Flatten() map[string]string {
 	flatten("", merged, outputMap)
 
 	return outputMap
+}
+
+func (c *ConfigMap) SaveConfig() error {
+	var configJSON, err = json.MarshalIndent(c.config, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(c.configPath, configJSON, 0644)
 }
 
 // ///

--- a/config/config_map_test.go
+++ b/config/config_map_test.go
@@ -18,10 +18,41 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+func TestSaveConfig(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	configMap, err := NewConfigMapBuilder().WithConfigJson(filepath.Join(tempDir, "config.json")).Build()
+	require.NoError(t, err)
+
+	err = configMap.Insert("key", "value")
+	require.NoError(t, err)
+
+	err = configMap.SaveConfig()
+	require.NoError(t, err)
+
+	// Read the saved file
+	savedJSON, err := os.ReadFile(configMap.configPath)
+	require.NoError(t, err)
+
+	// Unmarshal the JSON
+	var savedConfig map[string]interface{}
+	err = json.Unmarshal(savedJSON, &savedConfig)
+	require.NoError(t, err)
+
+	// Verify the saved config matches the original config
+	require.Equal(t, configMap.config, savedConfig)
+}
 
 func TestInsert(t *testing.T) {
 

--- a/config/config_tool_test.go
+++ b/config/config_tool_test.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func ExampleConfigTool_readValue() {
@@ -73,22 +74,16 @@ func TestConfigTool(t *testing.T) {
 
 		os.Args = []string{"config", "FOO=bar"}
 		err := ConfigTool(nuvRootPath, configPath)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		got, err := readConfigJson(tmpDir)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		want := map[string]interface{}{
 			"foo": "bar",
 		}
 
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
+		require.Equal(t, want, got)
 	})
 
 	t.Run("write values on existing config.json", func(t *testing.T) {
@@ -99,29 +94,21 @@ func TestConfigTool(t *testing.T) {
 
 		os.Args = []string{"config", "FOO=bar"}
 		err := ConfigTool(nuvRootPath, configPath)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		os.Args = []string{"config", "BAR=baz"}
 		err = ConfigTool(nuvRootPath, configPath)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		got, err := readConfigJson(tmpDir)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		want := map[string]interface{}{
 			"foo": "bar",
 			"bar": "baz",
 		}
 
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
+		require.Equal(t, want, got)
 	})
 
 	t.Run("write existing value is overridden", func(t *testing.T) {
@@ -132,28 +119,20 @@ func TestConfigTool(t *testing.T) {
 
 		os.Args = []string{"config", "FOO=bar"}
 		err := ConfigTool(nuvRootPath, configPath)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		os.Args = []string{"config", "FOO=new"}
 		err = ConfigTool(nuvRootPath, configPath)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		got, err := readConfigJson(tmpDir)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		want := map[string]interface{}{
 			"foo": "new",
 		}
 
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
+		require.Equal(t, want, got)
 	})
 
 	t.Run("write existing key object is merged", func(t *testing.T) {
@@ -164,20 +143,14 @@ func TestConfigTool(t *testing.T) {
 
 		os.Args = []string{"config", "FOO_BAR=bar"}
 		err := ConfigTool(nuvRootPath, configPath)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		os.Args = []string{"config", "FOO_BAZ=baz"}
 		err = ConfigTool(nuvRootPath, configPath)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		got, err := readConfigJson(tmpDir)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		want := map[string]interface{}{
 			"foo": map[string]interface{}{
@@ -186,9 +159,7 @@ func TestConfigTool(t *testing.T) {
 			},
 		}
 
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
+		require.Equal(t, want, got)
 	})
 
 	t.Run("write empty string to disable key", func(t *testing.T) {
@@ -199,20 +170,14 @@ func TestConfigTool(t *testing.T) {
 
 		os.Args = []string{"config", "FOO_BAR=bar"}
 		err := ConfigTool(nuvRootPath, configPath)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		os.Args = []string{"config", "FOO_BAR=\"\""}
 		err = ConfigTool(nuvRootPath, configPath)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		got, err := readConfigJson(tmpDir)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		want := map[string]interface{}{
 			"foo": map[string]interface{}{
@@ -220,9 +185,7 @@ func TestConfigTool(t *testing.T) {
 			},
 		}
 
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
+		require.Equal(t, want, got)
 	})
 
 	t.Run("remove existing key", func(t *testing.T) {
@@ -233,26 +196,18 @@ func TestConfigTool(t *testing.T) {
 
 		os.Args = []string{"config", "FOO=bar"}
 		err := ConfigTool(nuvRootPath, configPath)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		os.Args = []string{"config", "-r", "FOO"}
 		err = ConfigTool(nuvRootPath, configPath)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		got, err := readConfigJson(tmpDir)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		want := map[string]interface{}{}
 
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
+		require.Equal(t, want, got)
 	})
 
 	t.Run("remove nested key object", func(t *testing.T) {
@@ -263,32 +218,32 @@ func TestConfigTool(t *testing.T) {
 
 		os.Args = []string{"config", "FOO_BAR=bar", "FOO_BAZ=baz"}
 		err := ConfigTool(nuvRootPath, configPath)
-		if err != nil {
-			t.Errorf("error: %v", err)
+		require.NoError(t, err)
+
+		got, err := readConfigJson(tmpDir)
+		require.NoError(t, err)
+		want := map[string]interface{}{
+			"foo": map[string]interface{}{
+				"bar": "bar",
+				"baz": "baz",
+			},
 		}
-		j, _ := readConfigJson(tmpDir)
-		t.Logf("config.json: %s", j)
+		require.Equal(t, want, got)
 
 		os.Args = []string{"config", "-r", "FOO_BAR"}
 		err = ConfigTool(nuvRootPath, configPath)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
-		got, err := readConfigJson(tmpDir)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		got, err = readConfigJson(tmpDir)
+		require.NoError(t, err)
 
-		want := map[string]interface{}{
+		want = map[string]interface{}{
 			"foo": map[string]interface{}{
 				"baz": "baz",
 			},
 		}
 
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
+		require.Equal(t, want, got)
 	})
 
 	t.Run("remove non-existing key", func(t *testing.T) {
@@ -299,20 +254,14 @@ func TestConfigTool(t *testing.T) {
 
 		os.Args = []string{"config", "-r", "FOO"}
 		err := ConfigTool(nuvRootPath, configPath)
-		if err == nil {
-			t.Errorf("expected error, got nil")
-		}
+		require.Error(t, err)
 
 		got, err := readConfigJson(tmpDir)
-		if err != nil {
-			t.Errorf("error: %v", err)
-		}
+		require.NoError(t, err)
 
 		want := map[string]interface{}{}
 
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
+		require.Equal(t, want, got)
 	})
 }
 
@@ -359,12 +308,8 @@ func Test_buildKeyValueMap(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := buildInputKVMap(tc.input)
 
-			if tc.err != nil && (err == nil || err.Error() != tc.err.Error()) {
-				t.Errorf("Expected error %v, got %v", tc.err, err)
-			}
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("Expected %v, got %v", tc.want, got)
-			}
+			require.Equal(t, tc.err, err)
+			require.Equal(t, tc.want, got)
 		})
 	}
 }


### PR DESCRIPTION
This PR refactors the login command to store the returned secrets in the nuv config instead of the keyring store as a temporary solution, as the keyring store has some cases where it can't be used (when not present)

https://github.com/nuvolaris/nuvolaris/issues/224