### PR TITLE
Implements https://github.com/nuvolaris/nuvolaris/issues/225

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,6 +126,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	nuvRootDir := retrieveRootDir()
+
+	setupTmp()
 	// first argument with prefix "-" is an embedded tool
 	// using "-" or "--" or "-task" invokes embedded task
 	args := os.Args
@@ -221,10 +224,6 @@ func main() {
 		warn("unknown tool", "-"+cmd)
 		os.Exit(0)
 	}
-
-	nuvRootDir := retrieveRootDir()
-
-	setupTmp()
 
 	err = setAllConfigEnvVars(nuvRootDir, nuvHome)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ func info() {
 	fmt.Println("TMP:", os.Getenv("NUV_TMP"))
 	root, _ := getNuvRoot()
 	fmt.Println("ROOT:", root)
+	fmt.Println("NUV_PWD:", os.Getenv("NUV_PWD"))
 }
 
 func main() {
@@ -100,6 +101,12 @@ func main() {
 	// disable log
 	if os.Getenv("NUV_NO_LOG_PREFIX") != "" {
 		log.SetFlags(0)
+	}
+
+	if pwd, err := os.Getwd(); err != nil {
+		warn("unable to set NUV_PWD to working directory", err)
+	} else {
+		os.Setenv("NUV_PWD", pwd)
 	}
 
 	var err error

--- a/tests/realpath.bats
+++ b/tests/realpath.bats
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+setup() {
+    load 'test_helper/bats-support/load'
+    load 'test_helper/bats-assert/load'
+    export NO_COLOR=1
+}
+
+@test "-realpath help message" {
+    run nuv -realpath
+    assert_line "Usage: nuv -realpath <path>"
+
+    run nuv -realpath -h
+    assert_line "Usage: nuv -realpath <path>"
+}
+
+@test "-realpath with relative path" {
+    WD=$(pwd)
+    run nuv -realpath ./test
+    assert_success
+    assert_output "${WD}/test"
+}
+
+@test "-realpath with absolute path" {
+    WD=$(pwd)
+    run nuv -realpath "${WD}/test"
+    assert_success
+    assert_output "${WD}/test"
+
+    run nuv -realpath "${WD}/./test"
+    assert_success
+    assert_output "${WD}/test"
+}

--- a/tools/realpath.go
+++ b/tools/realpath.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package tools
 
 import (

--- a/tools/realpath.go
+++ b/tools/realpath.go
@@ -1,0 +1,50 @@
+package tools
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func realpathTool() error {
+	flags := flag.NewFlagSet("realpath", flag.ExitOnError)
+	flags.Usage = func() {
+		fmt.Println("Usage: nuv -realpath <path>")
+		fmt.Println()
+		fmt.Println("Options:")
+		flags.PrintDefaults()
+	}
+
+	showHelp := flags.Bool("h", false, "Show help")
+
+	// Parse command-line arguments
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		return err
+	}
+
+	if *showHelp {
+		flags.Usage()
+		return nil
+	}
+
+	if flags.NArg() != 1 {
+		flags.Usage()
+		return errors.New("no path provided")
+	}
+
+	path := flags.Arg(0)
+
+	var absPath string
+	if filepath.IsLocal(path) {
+		absPath = filepath.Join(os.Getenv("NUV_PWD"), path)
+	} else {
+		absPath = path
+	}
+
+	absPath = filepath.Clean(absPath)
+	fmt.Println(absPath)
+
+	return nil
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -26,6 +26,7 @@ import (
 	envsubst "github.com/nuvolaris/envsubst/cmd/envsubstmain"
 	replace "github.com/nuvolaris/go-replace"
 	"github.com/nuvolaris/goawk"
+	"golang.org/x/exp/slices"
 )
 
 // available in taskfiles
@@ -37,6 +38,7 @@ var tools = []string{
 	"config", "retry", "urlenc", "ssh",
 	"find", "replace", "base64", "validate",
 	"scan", "echoif", "echoifempty", "echoifexists",
+	"realpath",
 }
 
 // not available in taskfiles
@@ -178,6 +180,11 @@ func RunTool(name string, args []string) (int, error) {
 		if err := echoIfExistsTool(); err != nil {
 			return 1, err
 		}
+	case "realpath":
+		os.Args = append([]string{"realpath"}, args...)
+		if err := realpathTool(); err != nil {
+			return 1, err
+		}
 	}
 	return 0, nil
 }
@@ -186,6 +193,7 @@ func Help() {
 	fmt.Println("Available tools:")
 	availableTools := append(tools, extraTools...)
 	availableTools = append(availableTools, Utils...)
+	slices.Sort(availableTools)
 	for _, x := range availableTools {
 		fmt.Printf("-%s\n", x)
 	}


### PR DESCRIPTION
This PR closes https://github.com/nuvolaris/nuvolaris/issues/225

It adds the `nuv -realpath` tool that when a relative is passed, it prints $NUV_PWD/path where NUV_PWD is the directory where nuv was used. If it's an absolute path, it just prints it.

Also the PR adds a fix for the place where NUV_TMP is set so it appears in nuv -info