### PR TITLE
Add checks for curl and ssh

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,6 +109,12 @@ func main() {
 		os.Setenv("NUV_PWD", pwd)
 	}
 
+	// preflight checks
+	if err := preflightChecks(); err != nil {
+		log.Fatalf("[PREFLIGHT CHECK] error: %s", err.Error())
+	}
+	// ***************
+
 	var err error
 	me := os.Args[0]
 	if filepath.Base(me) == "nuv" || filepath.Base(me) == "nuv.exe" {

--- a/preflight.go
+++ b/preflight.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package main
 
 import (

--- a/preflight.go
+++ b/preflight.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"errors"
+	"os/exec"
+)
+
+type preflight struct {
+	err error
+}
+
+type checkFn func(pd *preflight)
+
+func (p *preflight) check(f checkFn) {
+
+	if p.err != nil {
+		// skip if previous check failed
+		return
+	}
+	f(p)
+}
+
+// preflightChecks performs preflight checks:
+// - curl is installed
+// - ssh is installed
+func preflightChecks() error {
+	trace("preflight checks")
+	preflight := preflight{}
+
+	preflight.check(curlInstalled)
+	preflight.check(sshInstalled)
+
+	return preflight.err
+}
+
+func curlInstalled(p *preflight) {
+	trace("check curl is installed")
+	_, err := exec.LookPath("curl")
+	if err != nil {
+		p.err = errors.New("curl is required but is not installed")
+	}
+}
+
+func sshInstalled(p *preflight) {
+	trace("check ssh is installed")
+	_, err := exec.LookPath("ssh")
+	if err != nil {
+		p.err = errors.New("ssh is required but is not installed")
+	}
+}

--- a/preflight_test.go
+++ b/preflight_test.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package main
 
 import (

--- a/preflight_test.go
+++ b/preflight_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testNoopCheck(p *preflight) {}
+func testErrCheck(p *preflight) {
+	p.err = errors.New("test error in check")
+}
+
+func Test_preflight(t *testing.T) {
+	p := preflight{}
+	p.check(testNoopCheck)
+	require.NoError(t, p.err)
+
+	p.err = errors.New("test error")
+	p.check(testNoopCheck)
+	require.Error(t, p.err)
+	require.Equal(t, "test error", p.err.Error())
+
+	p.err = nil
+	p.check(testErrCheck)
+	require.Error(t, p.err)
+	require.Equal(t, "test error in check", p.err.Error())
+}


### PR DESCRIPTION
This PR closes https://github.com/nuvolaris/nuvolaris/issues/239

It adds 2 preflight checks that are run when nuv is launched and it checks that curl and ssh are available in PATH