### PR TITLE
Update goja_nodes and zipf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/nuvolaris/goja v0.0.0-20230826140625-f4c22086ede6 // indirect
-	github.com/nuvolaris/goja_nodejs v0.0.0-20230830173113-e0ab07ae0f02 // indirect
+	github.com/nuvolaris/goja_nodejs v0.0.0-20230908085513-c4634a0b1160 // indirect
 	github.com/nuvolaris/sh/v3 v3.0.0-20230718131820-376e733299a4 // indirect
 	github.com/nuvolaris/task/v3 v3.9.3-0.20230718131831-48d06b3099ca // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -290,6 +290,14 @@ github.com/nuvolaris/goja_nodejs v0.0.0-20230830171817-96fda7aef746 h1:zovyJudao
 github.com/nuvolaris/goja_nodejs v0.0.0-20230830171817-96fda7aef746/go.mod h1:bik1pvnsEagEp/uCTjjKUHVWPyuy53ETukJZVuaSG2U=
 github.com/nuvolaris/goja_nodejs v0.0.0-20230830173113-e0ab07ae0f02 h1:Zy16V8qVX5ik3+D1uJT1p0oOVhumMV7cpDRozuNkquw=
 github.com/nuvolaris/goja_nodejs v0.0.0-20230830173113-e0ab07ae0f02/go.mod h1:bik1pvnsEagEp/uCTjjKUHVWPyuy53ETukJZVuaSG2U=
+github.com/nuvolaris/goja_nodejs v0.0.0-20230907081244-1f70814cad15 h1:XYf7CKq7ZP0GMTEVXA7EkMZ3O3VzJX6TfjbGDkV5hyo=
+github.com/nuvolaris/goja_nodejs v0.0.0-20230907081244-1f70814cad15/go.mod h1:bik1pvnsEagEp/uCTjjKUHVWPyuy53ETukJZVuaSG2U=
+github.com/nuvolaris/goja_nodejs v0.0.0-20230908084725-4fe8389b8bc8 h1:PJnckbBlyPRDSjOFb6jBO/UEU2MYZUdCKn24awKT1ME=
+github.com/nuvolaris/goja_nodejs v0.0.0-20230908084725-4fe8389b8bc8/go.mod h1:bik1pvnsEagEp/uCTjjKUHVWPyuy53ETukJZVuaSG2U=
+github.com/nuvolaris/goja_nodejs v0.0.0-20230908085230-3aacac3fb29b h1:Lq88pRXoo0z14m+WkkzMztrC9yfSg7mlMjwSmvv3EOk=
+github.com/nuvolaris/goja_nodejs v0.0.0-20230908085230-3aacac3fb29b/go.mod h1:bik1pvnsEagEp/uCTjjKUHVWPyuy53ETukJZVuaSG2U=
+github.com/nuvolaris/goja_nodejs v0.0.0-20230908085513-c4634a0b1160 h1:/PhIMFTHKYzupL5wnmwTKlqW2nrx+8GBs9gN82YW8Yw=
+github.com/nuvolaris/goja_nodejs v0.0.0-20230908085513-c4634a0b1160/go.mod h1:bik1pvnsEagEp/uCTjjKUHVWPyuy53ETukJZVuaSG2U=
 github.com/nuvolaris/openwhisk-cli/commands v0.0.0-20230615104118-d593f7d6576f h1:gYjKmnboe18DpSc4yIOa9Rqp4oQKIMbxzAt7NkSpEKQ=
 github.com/nuvolaris/openwhisk-cli/commands v0.0.0-20230615104118-d593f7d6576f/go.mod h1:Gv6ayVTiLPzMp3oA808nO5JxwXSN//vWxMu+qtG6Rf8=
 github.com/nuvolaris/openwhisk-cli/wski18n v0.0.0-20221227222349-fba31e174b7e h1:JEpF1YOoZKTU3U7k57Km3FytF6CaEAx0MkYIlGH5X34=

--- a/tools/zipf.go
+++ b/tools/zipf.go
@@ -60,9 +60,6 @@ Options:`)
 		return err
 	}
 
-	log.Println("zipf", flag.Args())
-	log.Println("zipf nargs", flag.NArg())
-
 	if *help {
 		flag.Usage()
 		return nil
@@ -94,6 +91,8 @@ Options:`)
 	if err != nil {
 		return err
 	}
+
+	log.Println("saving zip file to", *out)
 	return os.WriteFile(*out, stdout, 0644)
 }
 


### PR DESCRIPTION
This PR updates the deps for the updated goja_nodejs nuv module to be used for the deployer in olaris.