### PR TITLE
Add NUV_ROOT_PLUGIN to be used for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The following environment variables allows to ovverride certain defaults.
 - `NUV_PASSWORD`: set the password for `nuv -login`. If not 
 set, `nuv -login` will prompt for the password. It is useful for tests and non-interactive environments.
 - `NUV_PWD` is the folder where `nuv` is executed (the current working directory). It is used to preserve the original working directory when `nuv` is used again in tasks (e.g. nuv -realpath to retrieve the correct path). Change it only if you know what you are doing!
+- `NUV_ROOT_PLUGIN` is the folder where `nuv` looks for plugins. If not defined, it defaults to the same directory where  `nuv` is located.
 
 ## Where `nuv` looks for binaries 
 

--- a/main.go
+++ b/main.go
@@ -141,7 +141,8 @@ func main() {
 	}
 
 	setupTmp()
-	setupNuvPwd()
+	setNuvPwdEnv()
+	setNuvRootPluginEnv()
 
 	// first argument with prefix "-" is an embedded tool
 	// using "-" or "--" or "-task" invokes embedded task
@@ -335,7 +336,15 @@ func runNuv(baseDir string, args []string) error {
 	return err
 }
 
-func setupNuvPwd() {
+func setNuvRootPluginEnv() {
+	if os.Getenv("NUV_ROOT_PLUGIN") == "" {
+		//nolint:errcheck
+		os.Setenv("NUV_ROOT_PLUGIN", os.Getenv("NUV_PWD"))
+	}
+	trace("set NUV_ROOT_PLUGIN", os.Getenv("NUV_ROOT_PLUGIN"))
+}
+
+func setNuvPwdEnv() {
 	if os.Getenv("NUV_PWD") == "" {
 		dir, _ := os.Getwd()
 		//nolint:errcheck

--- a/main_test.go
+++ b/main_test.go
@@ -61,3 +61,20 @@ func TestMain(m *testing.M) {
 	//tracing = true
 	os.Exit(m.Run())
 }
+
+func TestSetupNuvRootPlugin(t *testing.T) {
+	// Test case 1: NUV_ROOT_PLUGIN is not set
+	os.Unsetenv("NUV_ROOT_PLUGIN")
+	os.Setenv("NUV_PWD", "/path/to/nuv")
+	setNuvRootPluginEnv()
+	if os.Getenv("NUV_ROOT_PLUGIN") != "/path/to/nuv" {
+		t.Errorf("NUV_ROOT_PLUGIN not set correctly, expected /path/to/nuv but got %s", os.Getenv("NUV_ROOT_PLUGIN"))
+	}
+
+	// Test case 2: NUV_ROOT_PLUGIN is already set
+	os.Setenv("NUV_ROOT_PLUGIN", "/path/to/nuv/root")
+	setNuvRootPluginEnv()
+	if os.Getenv("NUV_ROOT_PLUGIN") != "/path/to/nuv/root" {
+		t.Errorf("NUV_ROOT_PLUGIN not set correctly, expected /path/to/nuv/root but got %s", os.Getenv("NUV_ROOT_PLUGIN"))
+	}
+}

--- a/plugin.go
+++ b/plugin.go
@@ -203,7 +203,7 @@ type plugins struct {
 }
 
 func newPlugins() (*plugins, error) {
-	localDir := os.Getenv("NUV_PWD")
+	localDir := os.Getenv("NUV_ROOT_PLUGIN")
 	localOlarisFolders := make([]string, 0)
 	nuvOlarisFolders := make([]string, 0)
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -70,7 +70,7 @@ func TestGetAllNuvRootPlugins(t *testing.T) {
 	t.Run("success: get all the nuvroots.json from plugins with 1 plugin", func(t *testing.T) {
 		tempDir := t.TempDir()
 		plgFolder := setupPluginTest(tempDir, t)
-		os.Setenv("NUV_PWD", tempDir)
+		os.Setenv("NUV_ROOT_PLUGIN", tempDir)
 
 		nuvRoots, err := GetNuvRootPlugins()
 		require.NoError(t, err)
@@ -80,7 +80,7 @@ func TestGetAllNuvRootPlugins(t *testing.T) {
 
 	t.Run("success: get all the nuvroots.json from plugins with 2 plugins", func(t *testing.T) {
 		tempDir := t.TempDir()
-		os.Setenv("NUV_PWD", tempDir)
+		os.Setenv("NUV_ROOT_PLUGIN", tempDir)
 		plgFolder := setupPluginTest(tempDir, t)
 
 		// create the olaris-test2 folder
@@ -107,7 +107,7 @@ func TestGetAllNuvRootPlugins(t *testing.T) {
 
 	t.Run("empty: no plugins folder found (olaris-*)", func(t *testing.T) {
 		tempDir := t.TempDir()
-		os.Setenv("NUV_PWD", tempDir)
+		os.Setenv("NUV_ROOT_PLUGIN", tempDir)
 
 		// Test when the folder is not found
 		nuvRoots, err := GetNuvRootPlugins()
@@ -119,7 +119,7 @@ func TestGetAllNuvRootPlugins(t *testing.T) {
 func TestFindPluginTask(t *testing.T) {
 	t.Run("success: plugin task found in ./olaris-test", func(t *testing.T) {
 		tempDir := t.TempDir()
-		os.Setenv("NUV_PWD", tempDir)
+		os.Setenv("NUV_ROOT_PLUGIN", tempDir)
 		plgFolder := setupPluginTest(tempDir, t)
 
 		fld, err := findTaskInPlugins("test")
@@ -129,7 +129,7 @@ func TestFindPluginTask(t *testing.T) {
 
 	t.Run("error: no plugins folder found (olaris-*)", func(t *testing.T) {
 		tempDir := t.TempDir()
-		os.Setenv("NUV_PWD", tempDir)
+		os.Setenv("NUV_ROOT_PLUGIN", tempDir)
 
 		// Test when the folder is not found
 		fld, err := findTaskInPlugins("grep")
@@ -143,7 +143,7 @@ func TestNewPlugins(t *testing.T) {
 		tempDir := t.TempDir()
 		plgFolder := setupPluginTest(tempDir, t)
 
-		os.Setenv("NUV_PWD", tempDir)
+		os.Setenv("NUV_ROOT_PLUGIN", tempDir)
 
 		p, err := newPlugins()
 		require.NoError(t, err)
@@ -154,7 +154,7 @@ func TestNewPlugins(t *testing.T) {
 
 	t.Run("non existent local dir results in empty local field", func(t *testing.T) {
 		localDir := "/path/to/nonexistent/dir"
-		os.Setenv("NUV_PWD", localDir)
+		os.Setenv("NUV_ROOT_PLUGIN", localDir)
 		p, err := newPlugins()
 		require.NoError(t, err)
 		require.NotNil(t, p)


### PR DESCRIPTION
Close https://github.com/nuvolaris/nuvolaris/issues/297

This PR adds another env var NUV_ROOT_PLUGIN to customize the plugin folder root and separate it from NUV_PWD