### PR TITLE
Update nuv -login with NUV_APIHOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ The following environment variables allows to ovverride certain defaults.
 - `NUV_NO_NUVOPTS` can be defined to disable nuvopts parsing. Useful to test hidden tasks. When this is enabled it also shows all the tasks instead of just those with a description.
 - `NUV_PORT` is the port where `nuv` will run the web server. If not defined, it defaults to `9678`.
 - `NUV_TMP` is a temporary folder where you can store temp files - defaults to `~/.nuv/tmp`
-- `NUV_LOGIN`: set the username for `nuv -login`. The default is `nuvolaris`. It can be overriden by passing the username as an argument to `nuv -login`. 
-- `NUV_PASSWORD`: set the password for `nuv -login`. If not 
-set, `nuv -login` will prompt for the password. It is useful for tests and non-interactive environments.
+- `NUV_APIHOST` is the host for `nuv -login`. It is used in place of the first argument of `nuv -login`. If empty, the command will expect the first argument to be the apihost.
+- `NUV_USER`: set the username for `nuv -login`. The default is `nuvolaris`. It can be overriden by passing the username as an argument to `nuv -login` or by setting the environment variable.
+- `NUV_PASSWORD`: set the password for `nuv -login`. If not set, `nuv -login` will prompt for the password. It is useful for tests and non-interactive environments.
 - `NUV_PWD` is the folder where `nuv` is executed (the current working directory). It is used to preserve the original working directory when `nuv` is used again in tasks (e.g. nuv -realpath to retrieve the correct path). Change it only if you know what you are doing!
 - `NUV_ROOT_PLUGIN` is the folder where `nuv` looks for plugins. If not defined, it defaults to the same directory where  `nuv` is located.
 - `NUV_OLARIS` holds the head commit hash of the used olaris repo. You can see the hash with `nuv -info`.

--- a/tests/login.bats
+++ b/tests/login.bats
@@ -38,9 +38,40 @@ setup() {
     refute_line "Enter Password:"
 }
 
-@test "nuv -login with NUV_LOGIN env defines username" {
+@test "nuv -login with NUV_USER env defines username" {
     export NUV_PASSWORD=1234
-    export NUV_LOGIN=foo
+    export NUV_USER=foo
     run nuv -login localhost
     assert_line "Logging in as foo to localhost"
+}
+
+@test "nuv -login with NUV_USER and NUV_PASSWORD env" {
+    export NUV_PASSWORD=1234
+    export NUV_USER=foo
+    run nuv -login localhost
+    assert_line "Logging in as foo to localhost"
+    refute_line "Enter Password:"
+}
+
+@test "nuv -login with NUV_APIHOST env" {
+    export NUV_APIHOST=localhost
+    export NUV_PASSWORD=1234
+    run nuv -login
+    assert_line "Logging in as nuvolaris to localhost"
+}
+
+@test "nuv -login with NUV_APIHOST and NUV_USER env" {
+    export NUV_APIHOST=localhost
+    export NUV_USER=foo
+    export NUV_PASSWORD=1234
+    run nuv -login
+    assert_line "Logging in as foo to localhost"
+}
+
+@test "nuv -login with NUV_APIHOST, user is now first argument" {
+    export NUV_APIHOST=localhost
+    export NUV_PASSWORD=1234
+    run nuv -login hello
+    assert_line "Logging in as hello to localhost"
+    refute_line "Enter Password:"
 }


### PR DESCRIPTION
This PR closes https://github.com/nuvolaris/nuvolaris/issues/338 

It updates nuv -login with 3 env vars: "NUV_APIHOST", "NUV_USER" and "NUV_PASSWORD".

With NUV_APIHOST, you set the apihost and the first argument of nuv -login becomes the user. 
With NUV_USER you set the user and override any user argument.
With NUV_PASSWORD you set the password for the login and skip the interactive prompt.