### PR TITLE
refactor: move config env var above tool exec

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,6 +151,13 @@ func main() {
 		warn("unable to set NUV_OLARIS...", err.Error())
 	}
 
+	nuvRootDir := getRootDirOrExit()
+	debug("nuvRootDir", nuvRootDir)
+	err = setAllConfigEnvVars(nuvRootDir, nuvHome)
+	if err != nil {
+		log.Fatalf("cannot apply env vars from configs: %s", err.Error())
+	}
+
 	// first argument with prefix "-" is an embedded tool
 	// using "-" or "--" or "-task" invokes embedded task
 	trace("OS args:", os.Args)
@@ -248,13 +255,6 @@ func main() {
 			warn("unknown tool", "-"+cmd)
 		}
 		os.Exit(0)
-	}
-
-	nuvRootDir := getRootDirOrExit()
-	debug("nuvRootDir", nuvRootDir)
-	err = setAllConfigEnvVars(nuvRootDir, nuvHome)
-	if err != nil {
-		log.Fatalf("cannot apply env vars from configs: %s", err.Error())
 	}
 
 	// check if olaris was recently updated


### PR DESCRIPTION
This PR moves the application of the env vars from the config above the execution of tools and special tasks so the env vars are available in the tools