### PR TITLE
feat: shell with a derivation not yet on nixpkgs

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 { pkgs ? import <nixpkgs> {} }:
 let
   nuv = pkgs.callPackage ./nuv.nix { }; 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,4 +1,9 @@
 { pkgs ? import <nixpkgs> {} }:
-{
-  nuv = pkgs.callPackage ./nuv.nix { };
+let
+  nuv = pkgs.callPackage ./nuv.nix { }; 
+in
+pkgs.mkShell {
+  buildInputs = [
+    nuv
+  ];
 }

--- a/nix/nuv.nix
+++ b/nix/nuv.nix
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 { lib
 , stdenv
 , pkgs

--- a/nix/result
+++ b/nix/result
@@ -1,1 +1,0 @@
-/nix/store/hwka2xg8dk7fiff05p2dgjg9xa95za7p-nix-shell

--- a/nix/result
+++ b/nix/result
@@ -1,1 +1,1 @@
-/nix/store/jjhjaf218h7hmwzwi7ag284s33plfqig-nuv-3.0.1-beta.2405292059
+/nix/store/hwka2xg8dk7fiff05p2dgjg9xa95za7p-nix-shell


### PR DESCRIPTION
This show how to start a shell with a shell.nix including a derivation that is not yet on nixpkgs. Resolves [nuvolaris#175](https://github.com/nuvolaris/projects/issues/175)